### PR TITLE
feat: add 10 industry euphemism rules from Common Crawl audit

### DIFF
--- a/alex/animal-violence.yml
+++ b/alex/animal-violence.yml
@@ -520,3 +520,116 @@
     pre-existing: a
   inconsiderate:
     grandfathered: animal-violence
+# === Industry Euphemisms ===
+# Source: Common Crawl audit (CC-MAIN-2024-51)
+# Terms that sanitize animal agriculture practices in training data.
+- type: basic
+  note: >-
+    Industry commodity framing (24.8:1 ratio vs 'farmed animals' in training data).
+    Defines sentient beings by their commercial function.
+  considerate:
+    farmed animals: a
+    animals raised for food: a
+  inconsiderate:
+    livestock: animal-violence
+- type: basic
+  note: >-
+    Industry commodity framing (16.5:1 ratio vs 'farmed birds' in training data).
+    Abstracts individual birds into a bulk commodity term.
+  considerate:
+    farmed birds: a
+    chickens: a
+    chickens and turkeys: a
+  inconsiderate:
+    poultry: animal-violence
+- type: basic
+  note: >-
+    Industry euphemism (15.0:1 ratio vs 'pregnancy cage' in training data).
+    A metal enclosure so small a pregnant sow cannot turn around.
+  considerate:
+    pregnancy cage: a
+    pregnancy cages: a
+  inconsiderate:
+    gestation crate: animal-violence
+    gestation crates: animal-violence
+- type: basic
+  note: >-
+    Industry euphemism (13.9:1 ratio vs 'mass killing' in training data).
+    Used to describe killing entire flocks or herds. Suppress in database
+    or population statistics contexts.
+  considerate:
+    mass killing: a
+    mass culling: a
+  inconsiderate:
+    depopulation: animal-violence
+    depopulated: animal-violence
+    depopulating: animal-violence
+- type: basic
+  note: >-
+    Industry euphemism (34.3:1 ratio vs 'slaughterhouse' in training data).
+    Suppress in chemical, data, or manufacturing contexts.
+  considerate:
+    slaughterhouse: a
+    slaughterhouses: a
+  inconsiderate:
+    processing plant: animal-violence
+    processing plants: animal-violence
+    processing facility: animal-violence
+    processing facilities: animal-violence
+- type: basic
+  note: >-
+    Industry euphemism. A metal cage confining a sow during and after birth,
+    preventing her from turning around or reaching her piglets.
+  considerate:
+    birthing cage: a
+    birthing cages: a
+  inconsiderate:
+    farrowing crate: animal-violence
+    farrowing crates: animal-violence
+- type: basic
+  note: >-
+    Industry euphemism. Wire enclosures giving each hen less floor space
+    than a sheet of paper (67 sq inches).
+  considerate:
+    small wire cage: a
+    small wire cages: a
+    confined cage: a
+  inconsiderate:
+    battery cage: animal-violence
+    battery cages: animal-violence
+- type: basic
+  note: >-
+    Industry euphemism. 'Spent' frames a living hen as a depleted resource.
+    These hens are killed at 18 months (natural lifespan: 8-10 years).
+  considerate:
+    hen killed after egg production declines: a
+    discarded hen: a
+    discarded hens: a
+  inconsiderate:
+    spent hen: animal-violence
+    spent hens: animal-violence
+- type: basic
+  note: >-
+    Industry oxymoron. The adjective 'humane' sanitizes the act. USDA
+    standards permit bolt guns, electrocution, and gas chambers.
+  considerate:
+    slaughter: a
+    slaughtered: a
+    killing: a
+    killed: a
+  inconsiderate:
+    humane slaughter: animal-violence
+    humanely slaughtered: animal-violence
+    humane killing: animal-violence
+    humanely killed: animal-violence
+- type: basic
+  note: >-
+    Industry commodity term defining a living chicken entirely by its
+    commercial purpose. Suppress in kitchen appliance contexts.
+  considerate:
+    chicken raised for meat: a
+    chickens raised for meat: a
+    meat chicken: a
+  inconsiderate:
+    broiler: animal-violence
+    broilers: animal-violence

--- a/alex/animal-violence.yml
+++ b/alex/animal-violence.yml
@@ -528,108 +528,108 @@
     Industry commodity framing (24.8:1 ratio vs 'farmed animals' in training data).
     Defines sentient beings by their commercial function.
   considerate:
-    farmed animals: a
-    animals raised for food: a
+    farmed animals: industry-euphemism
+    animals raised for food: industry-euphemism
   inconsiderate:
-    livestock: animal-violence
+    livestock: industry-euphemism
 - type: basic
   note: >-
     Industry commodity framing (16.5:1 ratio vs 'farmed birds' in training data).
     Abstracts individual birds into a bulk commodity term.
   considerate:
-    farmed birds: a
-    chickens: a
-    chickens and turkeys: a
+    farmed birds: industry-euphemism
+    chickens: industry-euphemism
+    chickens and turkeys: industry-euphemism
   inconsiderate:
-    poultry: animal-violence
+    poultry: industry-euphemism
 - type: basic
   note: >-
     Industry euphemism (15.0:1 ratio vs 'pregnancy cage' in training data).
     A metal enclosure so small a pregnant sow cannot turn around.
   considerate:
-    pregnancy cage: a
-    pregnancy cages: a
+    pregnancy cage: industry-euphemism
+    pregnancy cages: industry-euphemism
   inconsiderate:
-    gestation crate: animal-violence
-    gestation crates: animal-violence
+    gestation crate: industry-euphemism
+    gestation crates: industry-euphemism
 - type: basic
   note: >-
     Industry euphemism (13.9:1 ratio vs 'mass killing' in training data).
     Used to describe killing entire flocks or herds. Suppress in database
     or population statistics contexts.
   considerate:
-    mass killing: a
-    mass culling: a
+    mass killing: industry-euphemism
+    mass culling: industry-euphemism
   inconsiderate:
-    depopulation: animal-violence
-    depopulated: animal-violence
-    depopulating: animal-violence
+    depopulation: industry-euphemism
+    depopulated: industry-euphemism
+    depopulating: industry-euphemism
 - type: basic
   note: >-
     Industry euphemism (34.3:1 ratio vs 'slaughterhouse' in training data).
     Suppress in chemical, data, or manufacturing contexts.
   considerate:
-    slaughterhouse: a
-    slaughterhouses: a
+    slaughterhouse: industry-euphemism
+    slaughterhouses: industry-euphemism
   inconsiderate:
-    processing plant: animal-violence
-    processing plants: animal-violence
-    processing facility: animal-violence
-    processing facilities: animal-violence
+    processing plant: industry-euphemism
+    processing plants: industry-euphemism
+    processing facility: industry-euphemism
+    processing facilities: industry-euphemism
 - type: basic
   note: >-
     Industry euphemism. A metal cage confining a sow during and after birth,
     preventing her from turning around or reaching her piglets.
   considerate:
-    birthing cage: a
-    birthing cages: a
+    birthing cage: industry-euphemism
+    birthing cages: industry-euphemism
   inconsiderate:
-    farrowing crate: animal-violence
-    farrowing crates: animal-violence
+    farrowing crate: industry-euphemism
+    farrowing crates: industry-euphemism
 - type: basic
   note: >-
     Industry euphemism. Wire enclosures giving each hen less floor space
     than a sheet of paper (67 sq inches).
   considerate:
-    small wire cage: a
-    small wire cages: a
-    confined cage: a
+    small wire cage: industry-euphemism
+    small wire cages: industry-euphemism
+    confined cage: industry-euphemism
   inconsiderate:
-    battery cage: animal-violence
-    battery cages: animal-violence
+    battery cage: industry-euphemism
+    battery cages: industry-euphemism
 - type: basic
   note: >-
     Industry euphemism. 'Spent' frames a living hen as a depleted resource.
     These hens are killed at 18 months (natural lifespan: 8-10 years).
   considerate:
-    hen killed after egg production declines: a
-    discarded hen: a
-    discarded hens: a
+    hen killed after egg production declines: industry-euphemism
+    discarded hen: industry-euphemism
+    discarded hens: industry-euphemism
   inconsiderate:
-    spent hen: animal-violence
-    spent hens: animal-violence
+    spent hen: industry-euphemism
+    spent hens: industry-euphemism
 - type: basic
   note: >-
     Industry oxymoron. The adjective 'humane' sanitizes the act. USDA
     standards permit bolt guns, electrocution, and gas chambers.
   considerate:
-    slaughter: a
-    slaughtered: a
-    killing: a
-    killed: a
+    slaughter: industry-euphemism
+    slaughtered: industry-euphemism
+    killing: industry-euphemism
+    killed: industry-euphemism
   inconsiderate:
-    humane slaughter: animal-violence
-    humanely slaughtered: animal-violence
-    humane killing: animal-violence
-    humanely killed: animal-violence
+    humane slaughter: industry-euphemism
+    humanely slaughtered: industry-euphemism
+    humane killing: industry-euphemism
+    humanely killed: industry-euphemism
 - type: basic
   note: >-
     Industry commodity term defining a living chicken entirely by its
     commercial purpose. Suppress in kitchen appliance contexts.
   considerate:
-    chicken raised for meat: a
-    chickens raised for meat: a
-    meat chicken: a
+    chicken raised for meat: industry-euphemism
+    chickens raised for meat: industry-euphemism
+    meat chicken: industry-euphemism
   inconsiderate:
-    broiler: animal-violence
-    broilers: animal-violence
+    broiler: industry-euphemism
+    broilers: industry-euphemism

--- a/vale/Speciesism/IndustryEuphemisms.yml
+++ b/vale/Speciesism/IndustryEuphemisms.yml
@@ -19,6 +19,8 @@ swap:
   'farrowing crates': birthing cages
   'battery cage': small wire cage
   'battery cages': small wire cages
+  'confined cage': small wire cage
+  'confined cages': small wire cages
   'spent hen': discarded hen
   'spent hens': discarded hens
   'humane slaughter': slaughter

--- a/vale/Speciesism/IndustryEuphemisms.yml
+++ b/vale/Speciesism/IndustryEuphemisms.yml
@@ -1,0 +1,29 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This is an industry euphemism that sanitizes animal agriculture practices."
+link: https://github.com/open-paws/common-crawl-audit
+level: warning
+ignorecase: true
+swap:
+  'livestock': farmed animals
+  'poultry': farmed birds
+  'gestation crate': pregnancy cage
+  'gestation crates': pregnancy cages
+  'depopulation': mass killing
+  'depopulated': mass killed
+  'depopulating': mass killing
+  'processing plant': slaughterhouse
+  'processing plants': slaughterhouses
+  'processing facility': slaughterhouse
+  'processing facilities': slaughterhouses
+  'farrowing crate': birthing cage
+  'farrowing crates': birthing cages
+  'battery cage': small wire cage
+  'battery cages': small wire cages
+  'spent hen': discarded hen
+  'spent hens': discarded hens
+  'humane slaughter': slaughter
+  'humanely slaughtered': slaughtered
+  'humane killing': killing
+  'humanely killed': killed
+  'broiler': chicken raised for meat
+  'broilers': chickens raised for meat

--- a/woke/.woke.yaml
+++ b/woke/.woke.yaml
@@ -929,7 +929,7 @@ rules:
     Suppress in chemical, data, or manufacturing contexts. When referring to
     facilities that kill animals, 'slaughterhouse' is the accurate term.
   options:
-    word_boundary: false
+    word_boundary: true
     categories:
     - industry-euphemism
 - name: farrowing-crate

--- a/woke/.woke.yaml
+++ b/woke/.woke.yaml
@@ -845,3 +845,181 @@ rules:
     word_boundary: true
     categories:
     - animal-violence
+# === Industry Euphemisms ===
+# Source: Common Crawl audit (CC-MAIN-2024-51), 105 euphemism pairs, 240+ domains
+# These terms sanitize animal agriculture practices. Ratios show how much more
+# frequently the euphemism appears vs the direct term in AI training data.
+- name: livestock
+  terms:
+  - livestock
+  alternatives:
+  - farmed animals
+  - animals raised for food
+  severity: warning
+  note: >-
+    Industry commodity framing (24.8:1 ratio vs 'farmed animals' in training data).
+    Defines sentient beings by their commercial function. 'Farmed animals' is
+    factually equivalent and does not erase the subject.
+  options:
+    word_boundary: true
+    categories:
+    - industry-euphemism
+- name: poultry
+  terms:
+  - poultry
+  alternatives:
+  - farmed birds
+  - chickens
+  - chickens and turkeys
+  severity: warning
+  note: >-
+    Industry commodity framing (16.5:1 ratio vs 'farmed birds' in training data).
+    Abstracts individual birds into a bulk commodity term. 'Farmed birds' or the
+    specific species name is more precise.
+  options:
+    word_boundary: true
+    categories:
+    - industry-euphemism
+- name: gestation-crate
+  terms:
+  - gestation crate
+  - gestation crates
+  alternatives:
+  - pregnancy cage
+  - pregnancy cages
+  severity: error
+  note: >-
+    Industry euphemism (15.0:1 ratio vs 'pregnancy cage' in training data).
+    A metal enclosure so small a pregnant sow cannot turn around for her
+    entire 3.5-month pregnancy. 'Pregnancy cage' describes what it actually is.
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+- name: depopulation
+  terms:
+  - depopulation
+  - depopulated
+  - depopulating
+  alternatives:
+  - mass killing
+  - mass culling
+  severity: warning
+  note: >-
+    Industry euphemism (13.9:1 ratio vs 'mass killing' in training data).
+    Used to describe killing entire flocks or herds, typically via gassing,
+    ventilation shutdown, or foam. Suppress in database or population
+    statistics contexts where 'depopulation' means removing data rows.
+  options:
+    word_boundary: true
+    categories:
+    - industry-euphemism
+- name: processing-plant
+  terms:
+  - processing plant
+  - processing plants
+  - processing facility
+  - processing facilities
+  alternatives:
+  - slaughterhouse
+  - slaughterhouses
+  severity: warning
+  note: >-
+    Industry euphemism (34.3:1 ratio vs 'slaughterhouse' in training data).
+    Suppress in chemical, data, or manufacturing contexts. When referring to
+    facilities that kill animals, 'slaughterhouse' is the accurate term.
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+- name: farrowing-crate
+  terms:
+  - farrowing crate
+  - farrowing crates
+  alternatives:
+  - birthing cage
+  - birthing cages
+  severity: error
+  note: >-
+    Industry euphemism. A metal cage that confines a sow during and after birth,
+    preventing her from turning around or reaching her piglets. 'Birthing cage'
+    describes the reality.
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+- name: battery-cage
+  terms:
+  - battery cage
+  - battery cages
+  alternatives:
+  - small wire cage
+  - small wire cages
+  - confined cage
+  - confined cages
+  severity: error
+  note: >-
+    Industry euphemism. Wire enclosures giving each hen less floor space than a
+    sheet of paper (67 sq inches / 432 sq cm). The word 'battery' obscures that
+    this is a tiny cage stacked in rows of thousands.
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+- name: spent-hen
+  terms:
+  - spent hen
+  - spent hens
+  alternatives:
+  - hen killed after egg production declines
+  - discarded hen
+  - discarded hens
+  severity: error
+  note: >-
+    Industry euphemism. 'Spent' frames a living hen as a depleted resource.
+    These hens are typically killed at 18 months (natural lifespan: 8-10 years)
+    when egg production drops below commercial thresholds.
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+- name: humane-slaughter
+  terms:
+  - humane slaughter
+  - humanely slaughtered
+  - humane killing
+  - humanely killed
+  alternatives:
+  - slaughter
+  - slaughtered
+  - killing
+  - killed
+  severity: error
+  note: >-
+    Industry oxymoron. The adjective 'humane' sanitizes the act. USDA
+    'humane slaughter' standards permit bolt guns, electrocution, and gas
+    chambers. The alternative drops the misleading modifier — the act is
+    slaughter regardless of method.
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+- name: broiler
+  terms:
+  - broiler
+  - broilers
+  alternatives:
+  - chicken raised for meat
+  - chickens raised for meat
+  - meat chicken
+  - meat chickens
+  severity: warning
+  note: >-
+    Industry commodity term that defines a living chicken entirely by its
+    commercial purpose. Suppress in kitchen appliance contexts (a broiler is
+    also an oven element). When referring to animals, 'chicken raised for meat'
+    is accurate without reducing the animal to a product category.
+  options:
+    word_boundary: true
+    categories:
+    - industry-euphemism

--- a/woke/.woke.yaml
+++ b/woke/.woke.yaml
@@ -971,9 +971,9 @@ rules:
   - spent hen
   - spent hens
   alternatives:
-  - hen killed after egg production declines
   - discarded hen
   - discarded hens
+  - hen killed after egg production declines
   severity: error
   note: >-
     Industry euphemism. 'Spent' frames a living hen as a depleted resource.


### PR DESCRIPTION
## Summary

Adds 10 industry euphemism rules derived from the Common Crawl training data audit (CC-MAIN-2024-51, 105 euphemism pairs, 240+ domains). These are the highest-frequency animal agriculture euphemisms missing from the ruleset — terms that appear 13-49x more often than their direct equivalents in AI training data.

All three formats updated: woke, alex/retext, Vale (new `IndustryEuphemisms.yml` file).

### New rules

| Rule | Euphemism | Alternative | Training data ratio |
|------|-----------|-------------|-------------------|
| 1 | livestock | farmed animals | 24.8:1 |
| 2 | poultry | farmed birds | 16.5:1 |
| 3 | gestation crate(s) | pregnancy cage(s) | 15.0:1 |
| 4 | depopulation | mass killing | 13.9:1 |
| 5 | processing plant | slaughterhouse | 34.3:1 |
| 6 | farrowing crate(s) | birthing cage(s) | — |
| 7 | battery cage(s) | small wire cage(s) | — |
| 8 | spent hen(s) | discarded hen(s) | — |
| 9 | humane slaughter | slaughter | — |
| 10 | broiler(s) | chicken(s) raised for meat | — |

### False positive analysis

- Scanned `structured-coding-with-ai` (137 files, 12 tool directories): **zero true false positives**
- 12 self-referential hits in advocacy domain dictionaries (the term "livestock" appears in glossaries explaining it should be replaced) — expected and correct behavior
- Each rule includes suppression context notes for known FP scenarios:
  - `depopulation`: database/population statistics contexts
  - `processing plant`: chemical/data/manufacturing contexts
  - `broiler`: kitchen appliance contexts
  - `livestock`, `poultry`: word-boundary enforced to prevent substring matches

### Category

New `industry-euphemism` category (distinct from existing `animal-violence`) enables downstream tools to filter by rule type.

## Test plan

- [x] All three YAML files pass `yaml.safe_load()` validation
- [x] Rule count: 62 → 72 in woke format (10 new)
- [x] False positive scan against `structured-coding-with-ai`: zero true FPs
- [ ] Verify woke detects new terms: `woke --config woke/.woke.yaml` against a test file containing all 10 terms
- [ ] Verify Vale detects new terms: `vale --config vale/ testfile.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded content linting system with new terminology detection rules and automated substitution suggestions. Added pattern-matching configurations across multiple checking platforms that identify specific phrases and recommend clearer alternatives. Enhanced content review capabilities to improve consistency and language standards with comprehensive automated detection of terminology patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->