### PR TITLE
feat: add cross-format consistency checker for the 9-repo suite

### DIFF
--- a/tools/check_consistency.py
+++ b/tools/check_consistency.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""
+Cross-format consistency checker for the no-animal-violence suite.
+
+Reads the canonical rule set from woke/.woke.yaml and checks downstream
+repos (ESLint, Semgrep, Vale) for drift: missing rules, extra rules,
+and alternative mismatches.
+
+Usage:
+    python tools/check_consistency.py [--repos-dir /path/to/repos]
+
+By default, looks for sibling directories:
+    ../eslint-plugin-no-animal-violence
+    ../semgrep-rules-no-animal-violence
+    ../vale-no-animal-violence
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class CanonicalRule:
+    """A rule from the canonical woke/.woke.yaml dictionary."""
+    name: str
+    terms: list[str]
+    alternatives: list[str]
+    severity: str
+    category: str
+
+    @property
+    def primary_term(self) -> str:
+        return self.terms[0] if self.terms else ""
+
+
+@dataclass
+class DriftFinding:
+    """A single consistency issue found in a downstream repo."""
+    downstream: str
+    rule_name: str
+    kind: str  # "missing", "extra", "alternative_mismatch"
+    detail: str
+
+
+@dataclass
+class DriftReport:
+    """Aggregated drift findings across all downstream repos."""
+    canonical_count: int = 0
+    findings: list[DriftFinding] = field(default_factory=list)
+    downstream_counts: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def has_drift(self) -> bool:
+        return len(self.findings) > 0
+
+    def summary(self) -> str:
+        lines = [
+            f"Canonical rules: {self.canonical_count}",
+            "",
+        ]
+        for ds, count in sorted(self.downstream_counts.items()):
+            lines.append(f"{ds}: {count} rules")
+
+        if not self.findings:
+            lines.append("\nNo drift detected. All formats are consistent.")
+            return "\n".join(lines)
+
+        lines.append(f"\nDrift findings: {len(self.findings)}")
+        lines.append("-" * 60)
+
+        by_downstream = {}
+        for f in self.findings:
+            by_downstream.setdefault(f.downstream, []).append(f)
+
+        for ds in sorted(by_downstream):
+            findings = by_downstream[ds]
+            missing = [f for f in findings if f.kind == "missing"]
+            extra = [f for f in findings if f.kind == "extra"]
+            mismatches = [f for f in findings if f.kind == "alternative_mismatch"]
+
+            lines.append(f"\n[{ds}]")
+            if missing:
+                lines.append(f"  Missing ({len(missing)}):")
+                for f in missing:
+                    lines.append(f"    - {f.rule_name}: {f.detail}")
+            if extra:
+                lines.append(f"  Extra ({len(extra)}):")
+                for f in extra:
+                    lines.append(f"    - {f.rule_name}: {f.detail}")
+            if mismatches:
+                lines.append(f"  Alternative mismatches ({len(mismatches)}):")
+                for f in mismatches:
+                    lines.append(f"    - {f.rule_name}: {f.detail}")
+
+        return "\n".join(lines)
+
+
+def load_canonical(repo_dir: Path) -> list[CanonicalRule]:
+    """Load canonical rules from woke/.woke.yaml."""
+    woke_path = repo_dir / "woke" / ".woke.yaml"
+    with open(woke_path) as f:
+        data = yaml.safe_load(f)
+
+    rules = []
+    for entry in data.get("rules", []):
+        category = "animal-violence"
+        cats = entry.get("options", {}).get("categories", [])
+        if cats:
+            category = cats[0]
+        rules.append(CanonicalRule(
+            name=entry["name"],
+            terms=[t.lower() for t in entry.get("terms", [])],
+            alternatives=[a.lower() for a in entry.get("alternatives", [])],
+            severity=entry.get("severity", "info"),
+            category=category,
+        ))
+    return rules
+
+
+def normalize_term(term: str) -> str:
+    """Normalize a term for comparison: lowercase, collapse whitespace."""
+    return re.sub(r"\s+", " ", term.lower().strip())
+
+
+def check_eslint(canonical: list[CanonicalRule], repos_dir: Path) -> list[DriftFinding]:
+    """Check ESLint plugin for drift against canonical rules."""
+    eslint_dir = repos_dir / "eslint-plugin-no-animal-violence"
+    rule_file = eslint_dir / "lib" / "rules" / "no-violent-language.js"
+    findings = []
+
+    if not rule_file.exists():
+        findings.append(DriftFinding(
+            downstream="eslint",
+            rule_name="*",
+            kind="missing",
+            detail=f"Rule file not found: {rule_file}",
+        ))
+        return findings
+
+    content = rule_file.read_text()
+
+    # Extract Map entries: ["phrase", "alternative"]
+    eslint_terms = {}
+    for match in re.finditer(r'\["([^"]+)",\s*"([^"]+)"\]', content):
+        term = normalize_term(match.group(1))
+        alt = match.group(2).lower().strip()
+        eslint_terms[term] = alt
+
+    # Check each canonical rule
+    for rule in canonical:
+        primary = normalize_term(rule.primary_term)
+        if primary in eslint_terms:
+            # Check if the primary alternative matches
+            eslint_alt = eslint_terms[primary]
+            canonical_primary_alt = rule.alternatives[0].lower() if rule.alternatives else ""
+            if eslint_alt != canonical_primary_alt:
+                findings.append(DriftFinding(
+                    downstream="eslint",
+                    rule_name=rule.name,
+                    kind="alternative_mismatch",
+                    detail=f"canonical='{canonical_primary_alt}', eslint='{eslint_alt}'",
+                ))
+        else:
+            # Check if any term variant matches
+            found = False
+            for term in rule.terms:
+                if normalize_term(term) in eslint_terms:
+                    found = True
+                    break
+            if not found:
+                findings.append(DriftFinding(
+                    downstream="eslint",
+                    rule_name=rule.name,
+                    kind="missing",
+                    detail=f"Term '{primary}' not found in ESLint plugin",
+                ))
+
+    # Check for extra rules in ESLint not in canonical
+    canonical_terms = set()
+    for rule in canonical:
+        for term in rule.terms:
+            canonical_terms.add(normalize_term(term))
+
+    for eslint_term in eslint_terms:
+        if eslint_term not in canonical_terms:
+            findings.append(DriftFinding(
+                downstream="eslint",
+                rule_name=eslint_term,
+                kind="extra",
+                detail=f"Term '{eslint_term}' in ESLint but not in canonical",
+            ))
+
+    return findings
+
+
+def check_semgrep(canonical: list[CanonicalRule], repos_dir: Path) -> list[DriftFinding]:
+    """Check Semgrep rules for drift against canonical rules."""
+    semgrep_dir = repos_dir / "semgrep-rules-no-animal-violence" / "rules"
+    findings = []
+
+    if not semgrep_dir.exists():
+        findings.append(DriftFinding(
+            downstream="semgrep",
+            rule_name="*",
+            kind="missing",
+            detail=f"Rules directory not found: {semgrep_dir}",
+        ))
+        return findings
+
+    # Load the generic rules file (most comparable to canonical)
+    generic_file = semgrep_dir / "animal-violence-generic.yaml"
+    if not generic_file.exists():
+        findings.append(DriftFinding(
+            downstream="semgrep",
+            rule_name="*",
+            kind="missing",
+            detail=f"Generic rules file not found: {generic_file}",
+        ))
+        return findings
+
+    with open(generic_file) as f:
+        data = yaml.safe_load(f)
+
+    # Extract Semgrep rule IDs and their regex patterns
+    semgrep_rules = {}
+    for entry in data.get("rules", []):
+        rule_id = entry.get("id", "")
+        # Extract the short name from the ID (e.g., "animal-violence.kill-two-birds" -> "kill-two-birds")
+        short_name = rule_id.replace("animal-violence.", "")
+        pattern = entry.get("pattern-regex", "")
+        alt = entry.get("metadata", {}).get("alternative", "")
+        semgrep_rules[short_name] = {
+            "id": rule_id,
+            "pattern": pattern,
+            "alternative": alt.lower(),
+        }
+
+    # Check each canonical rule against Semgrep
+    for rule in canonical:
+        if rule.name in semgrep_rules:
+            semgrep_alt = semgrep_rules[rule.name]["alternative"]
+            canonical_primary_alt = rule.alternatives[0].lower() if rule.alternatives else ""
+            if semgrep_alt and canonical_primary_alt and semgrep_alt != canonical_primary_alt:
+                findings.append(DriftFinding(
+                    downstream="semgrep",
+                    rule_name=rule.name,
+                    kind="alternative_mismatch",
+                    detail=f"canonical='{canonical_primary_alt}', semgrep='{semgrep_alt}'",
+                ))
+        else:
+            findings.append(DriftFinding(
+                downstream="semgrep",
+                rule_name=rule.name,
+                kind="missing",
+                detail=f"Rule '{rule.name}' not found in Semgrep generic rules",
+            ))
+
+    # Check for extra Semgrep rules
+    canonical_names = {r.name for r in canonical}
+    for semgrep_name in semgrep_rules:
+        if semgrep_name not in canonical_names:
+            findings.append(DriftFinding(
+                downstream="semgrep",
+                rule_name=semgrep_name,
+                kind="extra",
+                detail=f"Rule '{semgrep_name}' in Semgrep but not in canonical",
+            ))
+
+    return findings
+
+
+def check_vale(canonical: list[CanonicalRule], repos_dir: Path) -> list[DriftFinding]:
+    """Check Vale rules for drift against canonical rules."""
+    findings = []
+
+    # Check both the downstream vale repo AND the in-repo vale directory
+    vale_dirs = [
+        repos_dir / "vale-no-animal-violence",
+    ]
+
+    for vale_dir in vale_dirs:
+        if not vale_dir.exists():
+            findings.append(DriftFinding(
+                downstream=f"vale ({vale_dir.name})",
+                rule_name="*",
+                kind="missing",
+                detail=f"Vale directory not found: {vale_dir}",
+            ))
+            continue
+
+        # Find all Vale YAML files (skip meta.json, README)
+        vale_terms = {}
+        label = f"vale ({vale_dir.name})"
+
+        for yml_file in vale_dir.rglob("*.yml"):
+            if yml_file.name == "meta.json":
+                continue
+            try:
+                with open(yml_file) as f:
+                    data = yaml.safe_load(f)
+                if data and "swap" in data:
+                    for term, alt in data["swap"].items():
+                        # Strip YAML regex artifacts
+                        clean_term = re.sub(r"[\\()]", "", term).lower().strip()
+                        # Remove regex quantifiers like (?:ed|ing)?
+                        clean_term = re.sub(r"\?\:", "", clean_term)
+                        clean_term = re.sub(r"[?+*]", "", clean_term)
+                        vale_terms[clean_term] = alt.lower() if isinstance(alt, str) else str(alt).lower()
+            except Exception:
+                pass
+
+        # Check each canonical rule
+        for rule in canonical:
+            primary = normalize_term(rule.primary_term)
+            found = False
+            for term in rule.terms:
+                nt = normalize_term(term)
+                if nt in vale_terms:
+                    found = True
+                    vale_alt = vale_terms[nt]
+                    canonical_primary_alt = rule.alternatives[0].lower() if rule.alternatives else ""
+                    if canonical_primary_alt and vale_alt != canonical_primary_alt:
+                        findings.append(DriftFinding(
+                            downstream=label,
+                            rule_name=rule.name,
+                            kind="alternative_mismatch",
+                            detail=f"canonical='{canonical_primary_alt}', vale='{vale_alt}'",
+                        ))
+                    break
+            if not found:
+                findings.append(DriftFinding(
+                    downstream=label,
+                    rule_name=rule.name,
+                    kind="missing",
+                    detail=f"Term '{primary}' not found in Vale rules",
+                ))
+
+    return findings
+
+
+def run_check(repo_dir: Path, repos_dir: Path) -> DriftReport:
+    """Run full consistency check and return a report."""
+    canonical = load_canonical(repo_dir)
+    report = DriftReport(canonical_count=len(canonical))
+
+    # ESLint
+    eslint_findings = check_eslint(canonical, repos_dir)
+    report.findings.extend(eslint_findings)
+    eslint_dir = repos_dir / "eslint-plugin-no-animal-violence" / "lib" / "rules" / "no-violent-language.js"
+    if eslint_dir.exists():
+        content = eslint_dir.read_text()
+        report.downstream_counts["eslint"] = len(re.findall(r'\["[^"]+",\s*"[^"]+"', content))
+
+    # Semgrep
+    semgrep_findings = check_semgrep(canonical, repos_dir)
+    report.findings.extend(semgrep_findings)
+    semgrep_file = repos_dir / "semgrep-rules-no-animal-violence" / "rules" / "animal-violence-generic.yaml"
+    if semgrep_file.exists():
+        with open(semgrep_file) as f:
+            data = yaml.safe_load(f)
+        report.downstream_counts["semgrep (generic)"] = len(data.get("rules", []))
+
+    # Vale
+    vale_findings = check_vale(canonical, repos_dir)
+    report.findings.extend(vale_findings)
+    vale_dir = repos_dir / "vale-no-animal-violence"
+    if vale_dir.exists():
+        count = 0
+        for yml_file in vale_dir.rglob("*.yml"):
+            try:
+                with open(yml_file) as f:
+                    data = yaml.safe_load(f)
+                if data and "swap" in data:
+                    count += len(data["swap"])
+            except Exception:
+                pass
+        report.downstream_counts["vale"] = count
+
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check no-animal-violence suite consistency across formats"
+    )
+    parser.add_argument(
+        "--repos-dir",
+        type=Path,
+        default=None,
+        help="Directory containing sibling repos (default: parent of this repo)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output in JSON format",
+    )
+    args = parser.parse_args()
+
+    repo_dir = Path(__file__).resolve().parent.parent
+    repos_dir = args.repos_dir or repo_dir.parent
+
+    report = run_check(repo_dir, repos_dir)
+
+    if args.json:
+        output = {
+            "canonical_count": report.canonical_count,
+            "downstream_counts": report.downstream_counts,
+            "drift_count": len(report.findings),
+            "findings": [
+                {
+                    "downstream": f.downstream,
+                    "rule": f.rule_name,
+                    "kind": f.kind,
+                    "detail": f.detail,
+                }
+                for f in report.findings
+            ],
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print(report.summary())
+
+    sys.exit(1 if report.has_drift else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_consistency.py
+++ b/tools/check_consistency.py
@@ -18,7 +18,6 @@ By default, looks for sibling directories:
 import argparse
 import json
 import logging
-import os
 import re
 import sys
 from dataclasses import dataclass, field
@@ -108,8 +107,19 @@ class DriftReport:
 def load_canonical(repo_dir: Path) -> list[CanonicalRule]:
     """Load canonical rules from woke/.woke.yaml."""
     woke_path = repo_dir / "woke" / ".woke.yaml"
-    with open(woke_path) as f:
-        data = yaml.safe_load(f)
+    try:
+        with open(woke_path) as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError:
+        logger.error("Canonical rules file not found: %s", woke_path)
+        return []
+    except yaml.YAMLError as exc:
+        logger.error("Failed to parse canonical rules %s: %s", woke_path, exc)
+        return []
+
+    if not isinstance(data, dict):
+        logger.error("Canonical rules file is not a valid YAML mapping: %s", woke_path)
+        return []
 
     rules = []
     for entry in data.get("rules", []):
@@ -228,8 +238,17 @@ def check_semgrep(canonical: list[CanonicalRule], repos_dir: Path) -> list[Drift
         ))
         return findings
 
-    with open(generic_file) as f:
-        data = yaml.safe_load(f)
+    try:
+        with open(generic_file) as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        findings.append(DriftFinding(
+            downstream="semgrep",
+            rule_name="*",
+            kind="missing",
+            detail=f"Failed to parse Semgrep rules {generic_file}: {exc}",
+        ))
+        return findings
 
     # Extract Semgrep rule IDs and their regex patterns
     semgrep_rules = {}
@@ -299,13 +318,11 @@ def check_vale(canonical: list[CanonicalRule], repos_dir: Path) -> list[DriftFin
             ))
             continue
 
-        # Find all Vale YAML files (skip meta.json, README)
+        # Find all Vale YAML files
         vale_terms = {}
         label = f"vale ({vale_dir.name})"
 
         for yml_file in vale_dir.rglob("*.yml"):
-            if yml_file.name == "meta.json":
-                continue
             try:
                 with open(yml_file) as f:
                     data = yaml.safe_load(f)
@@ -317,7 +334,7 @@ def check_vale(canonical: list[CanonicalRule], repos_dir: Path) -> list[DriftFin
                         clean_term = re.sub(r"\?\:", "", clean_term)
                         clean_term = re.sub(r"[?+*]", "", clean_term)
                         vale_terms[clean_term] = alt.lower() if isinstance(alt, str) else str(alt).lower()
-            except Exception as exc:
+            except (yaml.YAMLError, OSError) as exc:
                 logger.debug("Failed to parse Vale file %s: %s", yml_file, exc)
 
         # Check each canonical rule
@@ -367,9 +384,12 @@ def run_check(repo_dir: Path, repos_dir: Path) -> DriftReport:
     report.findings.extend(semgrep_findings)
     semgrep_file = repos_dir / "semgrep-rules-no-animal-violence" / "rules" / "animal-violence-generic.yaml"
     if semgrep_file.exists():
-        with open(semgrep_file) as f:
-            data = yaml.safe_load(f)
-        report.downstream_counts["semgrep (generic)"] = len(data.get("rules", []))
+        try:
+            with open(semgrep_file) as f:
+                data = yaml.safe_load(f)
+            report.downstream_counts["semgrep (generic)"] = len(data.get("rules", []))
+        except yaml.YAMLError as exc:
+            logger.debug("Failed to parse Semgrep file for count: %s", exc)
 
     # Vale
     vale_findings = check_vale(canonical, repos_dir)
@@ -383,7 +403,7 @@ def run_check(repo_dir: Path, repos_dir: Path) -> DriftReport:
                     data = yaml.safe_load(f)
                 if data and "swap" in data:
                     count += len(data["swap"])
-            except Exception as exc:
+            except (yaml.YAMLError, OSError) as exc:
                 logger.debug("Failed to parse Vale file %s: %s", yml_file, exc)
         report.downstream_counts["vale"] = count
 

--- a/tools/check_consistency.py
+++ b/tools/check_consistency.py
@@ -17,6 +17,7 @@ By default, looks for sibling directories:
 
 import argparse
 import json
+import logging
 import os
 import re
 import sys
@@ -24,6 +25,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -233,7 +236,8 @@ def check_semgrep(canonical: list[CanonicalRule], repos_dir: Path) -> list[Drift
     for entry in data.get("rules", []):
         rule_id = entry.get("id", "")
         # Extract the short name from the ID (e.g., "animal-violence.kill-two-birds" -> "kill-two-birds")
-        short_name = rule_id.replace("animal-violence.", "")
+        prefix = "animal-violence."
+        short_name = rule_id[len(prefix):] if rule_id.startswith(prefix) else rule_id
         pattern = entry.get("pattern-regex", "")
         alt = entry.get("metadata", {}).get("alternative", "")
         semgrep_rules[short_name] = {
@@ -313,8 +317,8 @@ def check_vale(canonical: list[CanonicalRule], repos_dir: Path) -> list[DriftFin
                         clean_term = re.sub(r"\?\:", "", clean_term)
                         clean_term = re.sub(r"[?+*]", "", clean_term)
                         vale_terms[clean_term] = alt.lower() if isinstance(alt, str) else str(alt).lower()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Failed to parse Vale file %s: %s", yml_file, exc)
 
         # Check each canonical rule
         for rule in canonical:
@@ -353,9 +357,9 @@ def run_check(repo_dir: Path, repos_dir: Path) -> DriftReport:
     # ESLint
     eslint_findings = check_eslint(canonical, repos_dir)
     report.findings.extend(eslint_findings)
-    eslint_dir = repos_dir / "eslint-plugin-no-animal-violence" / "lib" / "rules" / "no-violent-language.js"
-    if eslint_dir.exists():
-        content = eslint_dir.read_text()
+    eslint_file = repos_dir / "eslint-plugin-no-animal-violence" / "lib" / "rules" / "no-violent-language.js"
+    if eslint_file.exists():
+        content = eslint_file.read_text()
         report.downstream_counts["eslint"] = len(re.findall(r'\["[^"]+",\s*"[^"]+"', content))
 
     # Semgrep
@@ -379,8 +383,8 @@ def run_check(repo_dir: Path, repos_dir: Path) -> DriftReport:
                     data = yaml.safe_load(f)
                 if data and "swap" in data:
                     count += len(data["swap"])
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Failed to parse Vale file %s: %s", yml_file, exc)
         report.downstream_counts["vale"] = count
 
     return report

--- a/tools/test_check_consistency.py
+++ b/tools/test_check_consistency.py
@@ -2,7 +2,7 @@
 """Tests for the cross-format consistency checker."""
 
 import json
-import os
+import shutil
 import tempfile
 from pathlib import Path
 from unittest import TestCase, main
@@ -77,6 +77,24 @@ def make_vale(swaps: dict[str, str], filename: str = "AnimalIdioms.yml") -> Path
     return tmpdir
 
 
+class TempDirTestCase(TestCase):
+    """Base test case that tracks and cleans up temporary directories."""
+
+    def setUp(self):
+        super().setUp()
+        self._temp_dirs: list[Path] = []
+
+    def tearDown(self):
+        for tmpdir in self._temp_dirs:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+        super().tearDown()
+
+    def track(self, path: Path) -> Path:
+        """Register a temp directory for cleanup and return it."""
+        self._temp_dirs.append(path)
+        return path
+
+
 SAMPLE_CANONICAL = [
     {
         "name": "kill-two-birds",
@@ -102,7 +120,7 @@ SAMPLE_CANONICAL = [
 ]
 
 
-class TestNormalizeTerm(TestCase):
+class TestNormalizeTerm(TempDirTestCase):
     def test_lowercase(self):
         self.assertEqual(normalize_term("Kill Two Birds"), "kill two birds")
 
@@ -113,9 +131,9 @@ class TestNormalizeTerm(TestCase):
         self.assertEqual(normalize_term("  livestock  "), "livestock")
 
 
-class TestLoadCanonical(TestCase):
+class TestLoadCanonical(TempDirTestCase):
     def test_loads_rules(self):
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         rules = load_canonical(repo_dir)
         self.assertEqual(len(rules), 3)
         self.assertEqual(rules[0].name, "kill-two-birds")
@@ -124,32 +142,45 @@ class TestLoadCanonical(TestCase):
         self.assertEqual(rules[0].category, "animal-violence")
 
     def test_category_from_options(self):
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         rules = load_canonical(repo_dir)
         self.assertEqual(rules[2].category, "industry-euphemism")
 
+    def test_missing_file(self):
+        repo_dir = self.track(Path(tempfile.mkdtemp()))
+        rules = load_canonical(repo_dir)
+        self.assertEqual(rules, [])
 
-class TestCheckEslint(TestCase):
+    def test_malformed_yaml(self):
+        repo_dir = self.track(Path(tempfile.mkdtemp()))
+        woke_dir = repo_dir / "woke"
+        woke_dir.mkdir()
+        (woke_dir / ".woke.yaml").write_text(": invalid: yaml: [")
+        rules = load_canonical(repo_dir)
+        self.assertEqual(rules, [])
+
+
+class TestCheckEslint(TempDirTestCase):
     def test_perfect_match(self):
         """ESLint has exactly the same rules — no drift."""
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         canonical = load_canonical(repo_dir)
-        repos_dir = make_eslint({
+        repos_dir = self.track(make_eslint({
             "kill two birds with one stone": "accomplish two things at once",
             "guinea pig": "test subject",
             "livestock": "farmed animals",
-        })
+        }))
         findings = check_eslint(canonical, repos_dir)
         self.assertEqual(len(findings), 0)
 
     def test_missing_rule(self):
         """ESLint is missing 'livestock' — should report drift."""
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         canonical = load_canonical(repo_dir)
-        repos_dir = make_eslint({
+        repos_dir = self.track(make_eslint({
             "kill two birds with one stone": "accomplish two things at once",
             "guinea pig": "test subject",
-        })
+        }))
         findings = check_eslint(canonical, repos_dir)
         missing = [f for f in findings if f.kind == "missing"]
         self.assertEqual(len(missing), 1)
@@ -157,14 +188,14 @@ class TestCheckEslint(TestCase):
 
     def test_extra_rule(self):
         """ESLint has a rule not in canonical — should report drift."""
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         canonical = load_canonical(repo_dir)
-        repos_dir = make_eslint({
+        repos_dir = self.track(make_eslint({
             "kill two birds with one stone": "accomplish two things at once",
             "guinea pig": "test subject",
             "livestock": "farmed animals",
             "some extra phrase": "replacement",
-        })
+        }))
         findings = check_eslint(canonical, repos_dir)
         extra = [f for f in findings if f.kind == "extra"]
         self.assertEqual(len(extra), 1)
@@ -172,13 +203,13 @@ class TestCheckEslint(TestCase):
 
     def test_alternative_mismatch(self):
         """ESLint has different alternative — should report drift."""
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         canonical = load_canonical(repo_dir)
-        repos_dir = make_eslint({
+        repos_dir = self.track(make_eslint({
             "kill two birds with one stone": "wrong alternative",
             "guinea pig": "test subject",
             "livestock": "farmed animals",
-        })
+        }))
         findings = check_eslint(canonical, repos_dir)
         mismatches = [f for f in findings if f.kind == "alternative_mismatch"]
         self.assertEqual(len(mismatches), 1)
@@ -186,18 +217,18 @@ class TestCheckEslint(TestCase):
 
     def test_missing_repo(self):
         """ESLint repo doesn't exist — should report gracefully."""
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         canonical = load_canonical(repo_dir)
-        repos_dir = Path(tempfile.mkdtemp())  # Empty dir
+        repos_dir = self.track(Path(tempfile.mkdtemp()))  # Empty dir
         findings = check_eslint(canonical, repos_dir)
         self.assertTrue(any(f.kind == "missing" and f.rule_name == "*" for f in findings))
 
 
-class TestCheckSemgrep(TestCase):
+class TestCheckSemgrep(TempDirTestCase):
     def test_perfect_match(self):
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         canonical = load_canonical(repo_dir)
-        repos_dir = make_semgrep([
+        repos_dir = self.track(make_semgrep([
             {
                 "id": "animal-violence.kill-two-birds",
                 "pattern-regex": "kill\\s+two\\s+birds",
@@ -219,14 +250,14 @@ class TestCheckSemgrep(TestCase):
                 "severity": "WARNING",
                 "metadata": {"alternative": "farmed animals"},
             },
-        ])
+        ]))
         findings = check_semgrep(canonical, repos_dir)
         self.assertEqual(len(findings), 0)
 
     def test_missing_rule(self):
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         canonical = load_canonical(repo_dir)
-        repos_dir = make_semgrep([
+        repos_dir = self.track(make_semgrep([
             {
                 "id": "animal-violence.kill-two-birds",
                 "pattern-regex": "kill\\s+two\\s+birds",
@@ -234,48 +265,48 @@ class TestCheckSemgrep(TestCase):
                 "severity": "ERROR",
                 "metadata": {"alternative": "accomplish two things at once"},
             },
-        ])
+        ]))
         findings = check_semgrep(canonical, repos_dir)
         missing = [f for f in findings if f.kind == "missing"]
         self.assertEqual(len(missing), 2)  # guinea-pig and livestock
 
 
-class TestCheckVale(TestCase):
+class TestCheckVale(TempDirTestCase):
     def test_perfect_match(self):
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         canonical = load_canonical(repo_dir)
-        repos_dir = make_vale({
+        repos_dir = self.track(make_vale({
             "kill two birds with one stone": "accomplish two things at once",
             "guinea pig": "test subject",
             "livestock": "farmed animals",
-        })
+        }))
         findings = check_vale(canonical, repos_dir)
         self.assertEqual(len(findings), 0)
 
     def test_missing_rule(self):
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         canonical = load_canonical(repo_dir)
-        repos_dir = make_vale({
+        repos_dir = self.track(make_vale({
             "kill two birds with one stone": "accomplish two things at once",
-        })
+        }))
         findings = check_vale(canonical, repos_dir)
         missing = [f for f in findings if f.kind == "missing"]
         self.assertEqual(len(missing), 2)
 
     def test_alternative_mismatch(self):
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
         canonical = load_canonical(repo_dir)
-        repos_dir = make_vale({
+        repos_dir = self.track(make_vale({
             "kill two birds with one stone": "different alternative",
             "guinea pig": "test subject",
             "livestock": "farmed animals",
-        })
+        }))
         findings = check_vale(canonical, repos_dir)
         mismatches = [f for f in findings if f.kind == "alternative_mismatch"]
         self.assertEqual(len(mismatches), 1)
 
 
-class TestDriftReport(TestCase):
+class TestDriftReport(TempDirTestCase):
     def test_no_drift(self):
         report = DriftReport(canonical_count=3)
         self.assertFalse(report.has_drift)
@@ -293,15 +324,15 @@ class TestDriftReport(TestCase):
         self.assertIn("[eslint]", report.summary())
 
 
-class TestRunCheckIntegration(TestCase):
+class TestRunCheckIntegration(TempDirTestCase):
     """Integration test using synthetic repos with known drift."""
 
     def test_detects_known_drift(self):
         """Create synthetic repos with intentional drift and verify detection."""
-        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        repo_dir = self.track(make_canonical(SAMPLE_CANONICAL))
 
         # ESLint: missing livestock
-        repos_dir = Path(tempfile.mkdtemp())
+        repos_dir = self.track(Path(tempfile.mkdtemp()))
         eslint_dir = repos_dir / "eslint-plugin-no-animal-violence" / "lib" / "rules"
         eslint_dir.mkdir(parents=True)
         (eslint_dir / "no-violent-language.js").write_text("""

--- a/tools/test_check_consistency.py
+++ b/tools/test_check_consistency.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Tests for the cross-format consistency checker."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest import TestCase, main
+
+import yaml
+
+from check_consistency import (
+    CanonicalRule,
+    DriftFinding,
+    DriftReport,
+    check_eslint,
+    check_semgrep,
+    check_vale,
+    load_canonical,
+    normalize_term,
+    run_check,
+)
+
+
+def make_canonical(rules_data: list[dict]) -> Path:
+    """Create a temporary canonical repo with woke rules."""
+    tmpdir = Path(tempfile.mkdtemp())
+    woke_dir = tmpdir / "woke"
+    woke_dir.mkdir()
+    woke_file = woke_dir / ".woke.yaml"
+    with open(woke_file, "w") as f:
+        yaml.dump({"rules": rules_data}, f)
+    return tmpdir
+
+
+def make_eslint(terms: dict[str, str]) -> Path:
+    """Create a temporary ESLint plugin with given terms."""
+    tmpdir = Path(tempfile.mkdtemp())
+    eslint_dir = tmpdir / "eslint-plugin-no-animal-violence" / "lib" / "rules"
+    eslint_dir.mkdir(parents=True)
+    entries = ", ".join(f'["{t}", "{a}"]' for t, a in terms.items())
+    content = f"""
+const VIOLENT_ANIMAL_PHRASES = new Map([{entries}]);
+module.exports = {{}};
+"""
+    (eslint_dir / "no-violent-language.js").write_text(content)
+    return tmpdir
+
+
+def make_semgrep(rules: list[dict]) -> Path:
+    """Create a temporary Semgrep rules directory."""
+    tmpdir = Path(tempfile.mkdtemp())
+    rules_dir = tmpdir / "semgrep-rules-no-animal-violence" / "rules"
+    rules_dir.mkdir(parents=True)
+    with open(rules_dir / "animal-violence-generic.yaml", "w") as f:
+        yaml.dump({"rules": rules}, f)
+    return tmpdir
+
+
+def make_vale(swaps: dict[str, str], filename: str = "AnimalIdioms.yml") -> Path:
+    """Create a temporary Vale rules directory."""
+    tmpdir = Path(tempfile.mkdtemp())
+    vale_dir = tmpdir / "vale-no-animal-violence" / "Speciesism"
+    vale_dir.mkdir(parents=True)
+    data = {
+        "extends": "substitution",
+        "message": "test",
+        "level": "warning",
+        "ignorecase": True,
+        "swap": swaps,
+    }
+    with open(vale_dir / filename, "w") as f:
+        yaml.dump(data, f)
+    # Also need meta.json
+    with open(vale_dir / "meta.json", "w") as f:
+        json.dump({"vale_version": ">=2.0.0"}, f)
+    return tmpdir
+
+
+SAMPLE_CANONICAL = [
+    {
+        "name": "kill-two-birds",
+        "terms": ["kill two birds with one stone"],
+        "alternatives": ["accomplish two things at once"],
+        "severity": "error",
+        "options": {"word_boundary": False, "categories": ["animal-violence"]},
+    },
+    {
+        "name": "guinea-pig",
+        "terms": ["guinea pig"],
+        "alternatives": ["test subject"],
+        "severity": "warning",
+        "options": {"word_boundary": True, "categories": ["animal-violence"]},
+    },
+    {
+        "name": "livestock",
+        "terms": ["livestock"],
+        "alternatives": ["farmed animals"],
+        "severity": "warning",
+        "options": {"word_boundary": True, "categories": ["industry-euphemism"]},
+    },
+]
+
+
+class TestNormalizeTerm(TestCase):
+    def test_lowercase(self):
+        self.assertEqual(normalize_term("Kill Two Birds"), "kill two birds")
+
+    def test_collapse_whitespace(self):
+        self.assertEqual(normalize_term("kill  two   birds"), "kill two birds")
+
+    def test_strip(self):
+        self.assertEqual(normalize_term("  livestock  "), "livestock")
+
+
+class TestLoadCanonical(TestCase):
+    def test_loads_rules(self):
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        rules = load_canonical(repo_dir)
+        self.assertEqual(len(rules), 3)
+        self.assertEqual(rules[0].name, "kill-two-birds")
+        self.assertEqual(rules[0].primary_term, "kill two birds with one stone")
+        self.assertEqual(rules[0].alternatives, ["accomplish two things at once"])
+        self.assertEqual(rules[0].category, "animal-violence")
+
+    def test_category_from_options(self):
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        rules = load_canonical(repo_dir)
+        self.assertEqual(rules[2].category, "industry-euphemism")
+
+
+class TestCheckEslint(TestCase):
+    def test_perfect_match(self):
+        """ESLint has exactly the same rules — no drift."""
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        canonical = load_canonical(repo_dir)
+        repos_dir = make_eslint({
+            "kill two birds with one stone": "accomplish two things at once",
+            "guinea pig": "test subject",
+            "livestock": "farmed animals",
+        })
+        findings = check_eslint(canonical, repos_dir)
+        self.assertEqual(len(findings), 0)
+
+    def test_missing_rule(self):
+        """ESLint is missing 'livestock' — should report drift."""
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        canonical = load_canonical(repo_dir)
+        repos_dir = make_eslint({
+            "kill two birds with one stone": "accomplish two things at once",
+            "guinea pig": "test subject",
+        })
+        findings = check_eslint(canonical, repos_dir)
+        missing = [f for f in findings if f.kind == "missing"]
+        self.assertEqual(len(missing), 1)
+        self.assertEqual(missing[0].rule_name, "livestock")
+
+    def test_extra_rule(self):
+        """ESLint has a rule not in canonical — should report drift."""
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        canonical = load_canonical(repo_dir)
+        repos_dir = make_eslint({
+            "kill two birds with one stone": "accomplish two things at once",
+            "guinea pig": "test subject",
+            "livestock": "farmed animals",
+            "some extra phrase": "replacement",
+        })
+        findings = check_eslint(canonical, repos_dir)
+        extra = [f for f in findings if f.kind == "extra"]
+        self.assertEqual(len(extra), 1)
+        self.assertIn("some extra phrase", extra[0].detail)
+
+    def test_alternative_mismatch(self):
+        """ESLint has different alternative — should report drift."""
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        canonical = load_canonical(repo_dir)
+        repos_dir = make_eslint({
+            "kill two birds with one stone": "wrong alternative",
+            "guinea pig": "test subject",
+            "livestock": "farmed animals",
+        })
+        findings = check_eslint(canonical, repos_dir)
+        mismatches = [f for f in findings if f.kind == "alternative_mismatch"]
+        self.assertEqual(len(mismatches), 1)
+        self.assertEqual(mismatches[0].rule_name, "kill-two-birds")
+
+    def test_missing_repo(self):
+        """ESLint repo doesn't exist — should report gracefully."""
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        canonical = load_canonical(repo_dir)
+        repos_dir = Path(tempfile.mkdtemp())  # Empty dir
+        findings = check_eslint(canonical, repos_dir)
+        self.assertTrue(any(f.kind == "missing" and f.rule_name == "*" for f in findings))
+
+
+class TestCheckSemgrep(TestCase):
+    def test_perfect_match(self):
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        canonical = load_canonical(repo_dir)
+        repos_dir = make_semgrep([
+            {
+                "id": "animal-violence.kill-two-birds",
+                "pattern-regex": "kill\\s+two\\s+birds",
+                "languages": ["generic"],
+                "severity": "ERROR",
+                "metadata": {"alternative": "accomplish two things at once"},
+            },
+            {
+                "id": "animal-violence.guinea-pig",
+                "pattern-regex": "guinea\\s+pig",
+                "languages": ["generic"],
+                "severity": "WARNING",
+                "metadata": {"alternative": "test subject"},
+            },
+            {
+                "id": "animal-violence.livestock",
+                "pattern-regex": "\\blivestock\\b",
+                "languages": ["generic"],
+                "severity": "WARNING",
+                "metadata": {"alternative": "farmed animals"},
+            },
+        ])
+        findings = check_semgrep(canonical, repos_dir)
+        self.assertEqual(len(findings), 0)
+
+    def test_missing_rule(self):
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        canonical = load_canonical(repo_dir)
+        repos_dir = make_semgrep([
+            {
+                "id": "animal-violence.kill-two-birds",
+                "pattern-regex": "kill\\s+two\\s+birds",
+                "languages": ["generic"],
+                "severity": "ERROR",
+                "metadata": {"alternative": "accomplish two things at once"},
+            },
+        ])
+        findings = check_semgrep(canonical, repos_dir)
+        missing = [f for f in findings if f.kind == "missing"]
+        self.assertEqual(len(missing), 2)  # guinea-pig and livestock
+
+
+class TestCheckVale(TestCase):
+    def test_perfect_match(self):
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        canonical = load_canonical(repo_dir)
+        repos_dir = make_vale({
+            "kill two birds with one stone": "accomplish two things at once",
+            "guinea pig": "test subject",
+            "livestock": "farmed animals",
+        })
+        findings = check_vale(canonical, repos_dir)
+        self.assertEqual(len(findings), 0)
+
+    def test_missing_rule(self):
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        canonical = load_canonical(repo_dir)
+        repos_dir = make_vale({
+            "kill two birds with one stone": "accomplish two things at once",
+        })
+        findings = check_vale(canonical, repos_dir)
+        missing = [f for f in findings if f.kind == "missing"]
+        self.assertEqual(len(missing), 2)
+
+    def test_alternative_mismatch(self):
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+        canonical = load_canonical(repo_dir)
+        repos_dir = make_vale({
+            "kill two birds with one stone": "different alternative",
+            "guinea pig": "test subject",
+            "livestock": "farmed animals",
+        })
+        findings = check_vale(canonical, repos_dir)
+        mismatches = [f for f in findings if f.kind == "alternative_mismatch"]
+        self.assertEqual(len(mismatches), 1)
+
+
+class TestDriftReport(TestCase):
+    def test_no_drift(self):
+        report = DriftReport(canonical_count=3)
+        self.assertFalse(report.has_drift)
+        self.assertIn("No drift detected", report.summary())
+
+    def test_with_drift(self):
+        report = DriftReport(
+            canonical_count=3,
+            findings=[
+                DriftFinding("eslint", "livestock", "missing", "Not found"),
+            ],
+        )
+        self.assertTrue(report.has_drift)
+        self.assertIn("Drift findings: 1", report.summary())
+        self.assertIn("[eslint]", report.summary())
+
+
+class TestRunCheckIntegration(TestCase):
+    """Integration test using synthetic repos with known drift."""
+
+    def test_detects_known_drift(self):
+        """Create synthetic repos with intentional drift and verify detection."""
+        repo_dir = make_canonical(SAMPLE_CANONICAL)
+
+        # ESLint: missing livestock
+        repos_dir = Path(tempfile.mkdtemp())
+        eslint_dir = repos_dir / "eslint-plugin-no-animal-violence" / "lib" / "rules"
+        eslint_dir.mkdir(parents=True)
+        (eslint_dir / "no-violent-language.js").write_text("""
+const VIOLENT_ANIMAL_PHRASES = new Map([
+    ["kill two birds with one stone", "accomplish two things at once"],
+    ["guinea pig", "test subject"],
+]);
+module.exports = {};
+""")
+
+        # Semgrep: has all 3 but wrong alternative for guinea-pig
+        semgrep_dir = repos_dir / "semgrep-rules-no-animal-violence" / "rules"
+        semgrep_dir.mkdir(parents=True)
+        with open(semgrep_dir / "animal-violence-generic.yaml", "w") as f:
+            yaml.dump({"rules": [
+                {"id": "animal-violence.kill-two-birds", "pattern-regex": "test",
+                 "languages": ["generic"], "severity": "ERROR",
+                 "metadata": {"alternative": "accomplish two things at once"}},
+                {"id": "animal-violence.guinea-pig", "pattern-regex": "test",
+                 "languages": ["generic"], "severity": "WARNING",
+                 "metadata": {"alternative": "early adopter"}},  # WRONG
+                {"id": "animal-violence.livestock", "pattern-regex": "test",
+                 "languages": ["generic"], "severity": "WARNING",
+                 "metadata": {"alternative": "farmed animals"}},
+            ]}, f)
+
+        # Vale: missing guinea-pig entirely
+        vale_dir = repos_dir / "vale-no-animal-violence" / "Speciesism"
+        vale_dir.mkdir(parents=True)
+        with open(vale_dir / "Rules.yml", "w") as f:
+            yaml.dump({
+                "extends": "substitution",
+                "message": "test",
+                "level": "warning",
+                "ignorecase": True,
+                "swap": {
+                    "kill two birds with one stone": "accomplish two things at once",
+                    "livestock": "farmed animals",
+                },
+            }, f)
+
+        report = run_check(repo_dir, repos_dir)
+
+        self.assertEqual(report.canonical_count, 3)
+        self.assertTrue(report.has_drift)
+
+        # ESLint should have 1 missing (livestock)
+        eslint_missing = [f for f in report.findings
+                          if f.downstream == "eslint" and f.kind == "missing"]
+        self.assertEqual(len(eslint_missing), 1)
+        self.assertEqual(eslint_missing[0].rule_name, "livestock")
+
+        # Semgrep should have 1 mismatch (guinea-pig)
+        semgrep_mismatches = [f for f in report.findings
+                              if f.downstream == "semgrep" and f.kind == "alternative_mismatch"]
+        self.assertEqual(len(semgrep_mismatches), 1)
+        self.assertEqual(semgrep_mismatches[0].rule_name, "guinea-pig")
+
+        # Vale should have 1 missing (guinea-pig)
+        vale_missing = [f for f in report.findings
+                        if "vale" in f.downstream and f.kind == "missing"]
+        self.assertEqual(len(vale_missing), 1)
+        self.assertEqual(vale_missing[0].rule_name, "guinea-pig")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a Python script that detects drift across the no-animal-violence suite by comparing downstream repos against the canonical `woke/.woke.yaml` dictionary.

- Parses ESLint plugin (JS Map), Semgrep generic rules (YAML), and Vale substitution rules (YAML)
- Reports: missing rules, extra rules, alternative mismatches
- Exits non-zero when drift detected (CI-friendly)
- `--json` flag for machine-readable output

### Immediate findings

Running against the current repos found **4 real drift instances** — all alternative mismatches between canonical and the Vale downstream:

| Rule | Canonical | Vale |
|------|-----------|------|
| wild-goose-chase | futile search | pointless pursuit |
| like-shooting-fish-in-a-barrel | trivially easy | extremely easy |
| red-herring | distraction | false lead |
| rat-race | daily grind | competitive grind |

ESLint and Semgrep (generic) are perfectly consistent at 62 rules each.

### Usage

```bash
# Check against sibling repos (default)
python tools/check_consistency.py

# Specify repos directory
python tools/check_consistency.py --repos-dir /path/to/repos

# JSON output for CI
python tools/check_consistency.py --json
```

## Test plan

- [x] 18 unit + integration tests passing
- [x] Tests cover: perfect match, missing rules, extra rules, alternative mismatches, missing repos (graceful), and a full integration test with synthetic repos containing known drift
- [x] Verified against real repos — correctly identifies 4 Vale drift instances
- [ ] Run in CI on canonical repo pushes to detect drift before it accumulates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistency validation tool that checks rule definitions across multiple downstream formats, ensuring alignment and detecting discrepancies.

* **Tests**
  * Added comprehensive test coverage for the validation tool, including scenarios for format compatibility, rule detection, and alternative matching verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->