### PR TITLE
docs: version compatibility matrix and check_versions script

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -6,6 +6,9 @@ name: Version Compatibility Check
 on:
   push:
     branches: [main]
+  schedule:
+    # Run every Monday at 09:00 UTC to catch tools that drift without a push
+    - cron: '0 9 * * 1'
   workflow_dispatch:
 
 jobs:
@@ -139,8 +142,20 @@ jobs:
           if (( OUTDATED > 0 )); then
             echo "RESULT: $OUTDATED stale pin(s) found. Update downstream repos to reference $CORE_TAG."
             echo "See VERSIONS.md for the compatibility matrix and update instructions."
+            # Write a job summary for GitHub UI
+            {
+              echo "## Version Check Failed"
+              echo ""
+              echo "$OUTDATED downstream tool(s) pin an outdated version of the core rules."
+              echo "Update them to reference \`$CORE_TAG\` and see [VERSIONS.md](../blob/main/VERSIONS.md) for instructions."
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           else
             echo "RESULT: All checked pins are consistent with core rules version $CORE_TAG."
+            {
+              echo "## Version Check Passed"
+              echo ""
+              echo "All downstream tool pins are consistent with core rules version \`$CORE_TAG\`."
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,146 @@
+name: Version Compatibility Check
+
+# Runs on push to main to verify that all downstream tool repos reference
+# the current rules version. A stale tool silently misses new violations.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  version-check:
+    name: Check downstream tool versions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine current core rules version
+        id: core-version
+        run: |
+          # Prefer a git tag on the current commit; fall back to the most recent tag.
+          TAG=$(git describe --tags --exact-match 2>/dev/null || git describe --tags --abbrev=0 2>/dev/null || echo "untagged")
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Core rules version: $TAG"
+
+      - name: Check tool repos for pinned rules version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CORE_TAG: ${{ steps.core-version.outputs.tag }}
+        run: |
+          set +e  # collect all results before deciding exit code
+
+          OUTDATED=0
+
+          check_npm_version() {
+            local label="$1"
+            local repo="$2"
+
+            local content
+            content=$(gh api "repos/Open-Paws/${repo}/contents/package.json" \
+              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null) || { echo "  SKIP  $label — could not read package.json"; return; }
+
+            local ver
+            ver=$(echo "$content" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('version','?'))" 2>/dev/null)
+            echo "  $label: $ver"
+          }
+
+          check_pip_version() {
+            local label="$1"
+            local repo="$2"
+
+            local content
+            content=$(gh api "repos/Open-Paws/${repo}/contents/setup.py" \
+              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null) || { echo "  SKIP  $label — could not read setup.py"; return; }
+
+            local ver
+            ver=$(echo "$content" | grep -oP "version\s*=\s*['\"]\\K[^'\"]*" | head -1)
+            echo "  $label: ${ver:-?}"
+          }
+
+          check_action_version() {
+            local label="$1"
+            local repo="$2"
+
+            local content
+            content=$(gh api "repos/Open-Paws/${repo}/contents/action.yml" \
+              --jq '.content' 2>/dev/null | base64 -d 2>/dev/null) || { echo "  SKIP  $label — could not read action.yml"; return; }
+
+            # Look for a version comment or tag reference inside the action
+            local ver
+            ver=$(echo "$content" | grep -oP "(?i)version[:\s]+\K[0-9]+\.[0-9]+\.[0-9]+" | head -1 || echo "no version field")
+            echo "  $label: ${ver}"
+          }
+
+          echo "=== Downstream tool versions ==="
+          check_npm_version "eslint-plugin-no-animal-violence"  "eslint-plugin-no-animal-violence"
+          check_npm_version "vscode-no-animal-violence"         "vscode-no-animal-violence"
+          check_npm_version "danger-plugin-no-animal-violence"  "danger-plugin-no-animal-violence"
+          check_pip_version "no-animal-violence-pre-commit"     "no-animal-violence-pre-commit"
+          check_action_version "no-animal-violence-action"      "no-animal-violence-action"
+          check_action_version "reviewdog-no-animal-violence"   "reviewdog-no-animal-violence"
+
+          echo ""
+          echo "=== Checking GitHub Action workflow pins in downstream repos ==="
+
+          check_action_pin() {
+            local label="$1"
+            local repo="$2"
+            local workflows
+
+            workflows=$(gh api "repos/Open-Paws/${repo}/contents/.github/workflows" \
+              --jq '.[].name' 2>/dev/null) || { echo "  SKIP  $label — no workflows found"; return; }
+
+            local stale_count=0
+            while IFS= read -r wf; do
+              local wf_content
+              wf_content=$(gh api "repos/Open-Paws/${repo}/contents/.github/workflows/${wf}" \
+                --jq '.content' 2>/dev/null | base64 -d 2>/dev/null) || continue
+
+              # Find any pins to this (no-animal-violence) repo's action refs
+              local pins
+              pins=$(echo "$wf_content" | grep -oP "Open-Paws/no-animal-violence[^@]*@\K[^\s]+" || true)
+
+              while IFS= read -r pin; do
+                [[ -z "$pin" ]] && continue
+                echo "  $label / $wf uses no-animal-violence@${pin}"
+                if [[ "$CORE_TAG" != "untagged" && "$pin" != "$CORE_TAG" ]]; then
+                  echo "    WARNING: pin $pin does not match current core tag $CORE_TAG"
+                  stale_count=$(( stale_count + 1 ))
+                fi
+              done <<<"$pins"
+            done <<<"$workflows"
+
+            if (( stale_count > 0 )); then
+              OUTDATED=$(( OUTDATED + stale_count ))
+            fi
+          }
+
+          REPOS=(
+            "eslint-plugin-no-animal-violence"
+            "vscode-no-animal-violence"
+            "semgrep-rules-no-animal-violence"
+            "vale-no-animal-violence"
+            "no-animal-violence-pre-commit"
+            "no-animal-violence-action"
+            "reviewdog-no-animal-violence"
+            "danger-plugin-no-animal-violence"
+          )
+
+          for r in "${REPOS[@]}"; do
+            check_action_pin "$r" "$r"
+          done
+
+          echo ""
+          if (( OUTDATED > 0 )); then
+            echo "RESULT: $OUTDATED stale pin(s) found. Update downstream repos to reference $CORE_TAG."
+            echo "See VERSIONS.md for the compatibility matrix and update instructions."
+            exit 1
+          else
+            echo "RESULT: All checked pins are consistent with core rules version $CORE_TAG."
+            exit 0
+          fi

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,0 +1,109 @@
+# Version Compatibility Matrix
+
+This document tracks which version of each downstream tool is compatible with each version of the core rule set in this repository.
+
+A stale tool silently misses new violations. Use `scripts/check_versions.sh` to detect drift automatically.
+
+## Versioning Policy
+
+| Increment | Meaning | Effect on suppressions |
+|-----------|---------|----------------------|
+| **Patch** (x.y.**Z**) | New rules added | No existing suppressions break |
+| **Minor** (x.**Y**.0) | Rule text or IDs changed | Existing suppressions may stop matching |
+| **Major** (**X**.0.0) | Rule format changed | Full re-validation required for all consumers |
+
+**Consumers must upgrade to at least the minimum compatible version shown below.** Being more than one minor version behind means you are silently missing violation categories.
+
+## Compatibility Matrix
+
+| Core Rules | ESLint Plugin | VS Code Extension | Semgrep Rules | Vale Package | Pre-commit Hook | GitHub Action | Reviewdog Runner | Danger Plugin |
+|-----------|--------------|-------------------|---------------|--------------|-----------------|---------------|------------------|---------------|
+| 0.1.x | ≥ 0.1.0 | ≥ 0.1.0 | ≥ 0.1.0 | ≥ 0.1.0 | ≥ 0.1.0 | ≥ 0.1.0 | ≥ 0.1.0 | ≥ 0.1.0 |
+
+> **Note:** No tool repos have published a tagged release yet. All tools are at version `0.1.0` (from `package.json` / `setup.py`). This matrix will be updated as tagged releases are published. See [Releasing](#releasing) below.
+
+## How to Check Your Installed Versions
+
+Run one command per tool to see what you currently have:
+
+```bash
+# ESLint plugin
+npm list eslint-plugin-no-animal-violence 2>/dev/null | grep eslint-plugin-no-animal-violence
+
+# VS Code extension (requires vsce or check the Extensions panel)
+code --list-extensions | grep no-animal-violence
+
+# Semgrep rules (pinned via git or semgrep registry)
+# If cloned locally:
+git -C path/to/semgrep-rules-no-animal-violence describe --tags 2>/dev/null || echo "no tags"
+
+# Vale package
+vale ls-config 2>/dev/null | grep -i "no-animal-violence\|speciesism" || echo "check .vale.ini"
+
+# Pre-commit hook (installed via pip)
+pip show no-animal-violence-pre-commit 2>/dev/null | grep Version
+
+# GitHub Action — check your workflow file
+grep -r "Open-Paws/no-animal-violence-action" .github/workflows/
+
+# Reviewdog runner — check your workflow file
+grep -r "Open-Paws/reviewdog-no-animal-violence" .github/workflows/
+
+# Danger plugin
+npm list danger-plugin-no-animal-violence 2>/dev/null | grep danger-plugin-no-animal-violence
+```
+
+Or run everything at once:
+
+```bash
+./scripts/check_versions.sh
+```
+
+## How to Update All Tools
+
+```bash
+# ESLint plugin
+npm install eslint-plugin-no-animal-violence@latest
+
+# Danger plugin
+npm install --save-dev danger-plugin-no-animal-violence@latest
+
+# Pre-commit hook
+pip install --upgrade no-animal-violence-pre-commit
+
+# Vale package — update the Packages line in .vale.ini to pin a new tag:
+# Packages = https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/Speciesism.zip
+vale sync
+
+# VS Code extension — update from the Extensions panel or:
+code --install-extension Open-Paws.no-animal-violence --force
+
+# GitHub Action and Reviewdog runner — bump the `@` pin in your workflow files:
+# uses: Open-Paws/no-animal-violence-action@v0.1.0  →  @vX.Y.Z
+# uses: Open-Paws/reviewdog-no-animal-violence@v0.1.0  →  @vX.Y.Z
+
+# Semgrep rules (if cloned locally)
+git -C path/to/semgrep-rules-no-animal-violence pull --tags
+```
+
+## Releasing
+
+When releasing a new version of this core rule set:
+
+1. Tag this repo: `git tag vX.Y.Z && git push origin vX.Y.Z`
+2. Update the compatibility matrix above in a PR against main
+3. Open issues in each downstream tool repo to pull the new rules in
+4. Once downstream tools release, fill in their minimum compatible version in the matrix
+
+## Tool Repositories
+
+| Tool | Repository | Purpose |
+|------|-----------|---------|
+| ESLint Plugin | [eslint-plugin-no-animal-violence](https://github.com/Open-Paws/eslint-plugin-no-animal-violence) | JS/TS linting |
+| VS Code Extension | [vscode-no-animal-violence](https://github.com/Open-Paws/vscode-no-animal-violence) | Real-time editor detection |
+| Semgrep Rules | [semgrep-rules-no-animal-violence](https://github.com/Open-Paws/semgrep-rules-no-animal-violence) | Multi-language static analysis |
+| Vale Package | [vale-no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) | Prose and documentation |
+| Pre-commit Hook | [no-animal-violence-pre-commit](https://github.com/Open-Paws/no-animal-violence-pre-commit) | Blocks commits with violations |
+| GitHub Action | [no-animal-violence-action](https://github.com/Open-Paws/no-animal-violence-action) | CI/CD PR scanning |
+| Reviewdog Runner | [reviewdog-no-animal-violence](https://github.com/Open-Paws/reviewdog-no-animal-violence) | Inline PR annotations |
+| Danger Plugin | [danger-plugin-no-animal-violence](https://github.com/Open-Paws/danger-plugin-no-animal-violence) | Danger.js PR review |

--- a/scripts/check_versions.sh
+++ b/scripts/check_versions.sh
@@ -214,13 +214,20 @@ check_tool "Danger Plugin"      "danger-plugin-no-animal-violence"  "$(installed
 
 OUTDATED=0
 
+# Count outdated tools once (shared by both output modes)
+TOOLS_LIST=("ESLint Plugin" "VS Code Extension" "Semgrep Rules" "Vale Package" "Pre-commit Hook" "GitHub Action" "Reviewdog Runner" "Danger Plugin")
+for _label in "${TOOLS_LIST[@]}"; do
+  if [[ "${STATUS[$_label]:-}" == "outdated" ]]; then
+    OUTDATED=$(( OUTDATED + 1 ))
+  fi
+done
+
 if $JSON_OUTPUT; then
   # Build JSON directly from bash associative arrays using printf
   printf '{\n'
-  TOOLS_JSON=("ESLint Plugin" "VS Code Extension" "Semgrep Rules" "Vale Package" "Pre-commit Hook" "GitHub Action" "Reviewdog Runner" "Danger Plugin")
-  last_idx=$(( ${#TOOLS_JSON[@]} - 1 ))
-  for idx in "${!TOOLS_JSON[@]}"; do
-    label="${TOOLS_JSON[$idx]}"
+  last_idx=$(( ${#TOOLS_LIST[@]} - 1 ))
+  for idx in "${!TOOLS_LIST[@]}"; do
+    label="${TOOLS_LIST[$idx]}"
     comma=$( (( idx < last_idx )) && echo ',' || echo '' )
     printf '  "%s": {"installed": "%s", "latest": "%s", "status": "%s"}%s\n' \
       "$label" \
@@ -230,6 +237,7 @@ if $JSON_OUTPUT; then
       "$comma"
   done
   printf '}\n'
+  (( OUTDATED == 0 )) && exit 0 || exit 1
 else
   echo ""
   echo "no-animal-violence tool version check"
@@ -237,9 +245,7 @@ else
   printf "%-22s %-18s %-18s %s\n" "Tool" "Installed" "Latest" "Status"
   printf "%-22s %-18s %-18s %s\n" "----" "---------" "------" "------"
 
-  TOOLS=("ESLint Plugin" "VS Code Extension" "Semgrep Rules" "Vale Package" "Pre-commit Hook" "GitHub Action" "Reviewdog Runner" "Danger Plugin")
-
-  for label in "${TOOLS[@]}"; do
+  for label in "${TOOLS_LIST[@]}"; do
     installed="${INSTALLED_VERSIONS[$label]}"
     latest="${LATEST_VERSIONS[$label]}"
     st="${STATUS[$label]}"
@@ -247,7 +253,7 @@ else
     case "$st" in
       ok)            status_str="${GREEN}up to date${RESET}" ;;
       warn)          status_str="${YELLOW}behind (< 1 minor)${RESET}" ;;
-      outdated)      status_str="${RED}OUTDATED (> 1 minor behind)${RESET}"; OUTDATED=1 ;;
+      outdated)      status_str="${RED}OUTDATED (> 1 minor behind)${RESET}" ;;
       not_installed) status_str="not installed" ;;
       *)             status_str="unknown" ;;
     esac

--- a/scripts/check_versions.sh
+++ b/scripts/check_versions.sh
@@ -47,6 +47,7 @@ version_gte() {
   local a="$1" b="$2"
   # Strip leading 'v'
   a="${a#v}"; b="${b#v}"
+  local a_maj a_min a_pat b_maj b_min b_pat
   IFS='.' read -r a_maj a_min a_pat <<<"$a"
   IFS='.' read -r b_maj b_min b_pat <<<"$b"
   a_maj="${a_maj:-0}"; a_min="${a_min:-0}"; a_pat="${a_pat:-0}"
@@ -64,6 +65,7 @@ version_gte() {
 more_than_one_minor_behind() {
   local installed="$1" latest="$2"
   installed="${installed#v}"; latest="${latest#v}"
+  local i_maj i_min l_maj l_min
   IFS='.' read -r i_maj i_min _ <<<"$installed"
   IFS='.' read -r l_maj l_min _ <<<"$latest"
   i_maj="${i_maj:-0}"; i_min="${i_min:-0}"
@@ -213,25 +215,21 @@ check_tool "Danger Plugin"      "danger-plugin-no-animal-violence"  "$(installed
 OUTDATED=0
 
 if $JSON_OUTPUT; then
-  python3 - <<'PYEOF'
-import json, os, sys
-
-tools = [
-  "ESLint Plugin", "VS Code Extension", "Semgrep Rules", "Vale Package",
-  "Pre-commit Hook", "GitHub Action", "Reviewdog Runner", "Danger Plugin"
-]
-
-# Read from environment — bash exports set before calling python
-result = {}
-for t in tools:
-  key = t.replace(" ", "_").upper()
-  result[t] = {
-    "installed": os.environ.get(f"INSTALLED_{key}", ""),
-    "latest":    os.environ.get(f"LATEST_{key}", ""),
-    "status":    os.environ.get(f"STATUS_{key}", ""),
-  }
-print(json.dumps(result, indent=2))
-PYEOF
+  # Build JSON directly from bash associative arrays using printf
+  printf '{\n'
+  TOOLS_JSON=("ESLint Plugin" "VS Code Extension" "Semgrep Rules" "Vale Package" "Pre-commit Hook" "GitHub Action" "Reviewdog Runner" "Danger Plugin")
+  last_idx=$(( ${#TOOLS_JSON[@]} - 1 ))
+  for idx in "${!TOOLS_JSON[@]}"; do
+    label="${TOOLS_JSON[$idx]}"
+    comma=$( (( idx < last_idx )) && echo ',' || echo '' )
+    printf '  "%s": {"installed": "%s", "latest": "%s", "status": "%s"}%s\n' \
+      "$label" \
+      "${INSTALLED_VERSIONS[$label]:-}" \
+      "${LATEST_VERSIONS[$label]:-}" \
+      "${STATUS[$label]:-}" \
+      "$comma"
+  done
+  printf '}\n'
 else
   echo ""
   echo "no-animal-violence tool version check"

--- a/scripts/check_versions.sh
+++ b/scripts/check_versions.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# check_versions.sh — Verify that installed no-animal-violence tools are up to date.
+#
+# Checks currently-installed versions of each tool against the latest published
+# releases on GitHub. Warns if any tool is more than one minor version behind.
+#
+# Usage: ./scripts/check_versions.sh [--json]
+#
+# Exit codes:
+#   0  All tools are up to date (or not installed)
+#   1  One or more installed tools are outdated
+#   2  A required dependency (curl, jq) is missing
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+JSON_OUTPUT=false
+if [[ "${1:-}" == "--json" ]]; then
+  JSON_OUTPUT=true
+fi
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: '$cmd' is required but not installed." >&2
+    exit 2
+  fi
+}
+
+require_cmd curl
+require_cmd jq
+
+# ---------------------------------------------------------------------------
+# Version arithmetic
+# ---------------------------------------------------------------------------
+
+# Returns 0 if $1 >= $2 (semver, major.minor.patch)
+version_gte() {
+  local a="$1" b="$2"
+  # Strip leading 'v'
+  a="${a#v}"; b="${b#v}"
+  IFS='.' read -r a_maj a_min a_pat <<<"$a"
+  IFS='.' read -r b_maj b_min b_pat <<<"$b"
+  a_maj="${a_maj:-0}"; a_min="${a_min:-0}"; a_pat="${a_pat:-0}"
+  b_maj="${b_maj:-0}"; b_min="${b_min:-0}"; b_pat="${b_pat:-0}"
+  if   (( a_maj > b_maj )); then return 0
+  elif (( a_maj < b_maj )); then return 1
+  elif (( a_min > b_min )); then return 0
+  elif (( a_min < b_min )); then return 1
+  elif (( a_pat >= b_pat )); then return 0
+  else return 1
+  fi
+}
+
+# Returns 0 if installed version is more than one minor behind latest
+more_than_one_minor_behind() {
+  local installed="$1" latest="$2"
+  installed="${installed#v}"; latest="${latest#v}"
+  IFS='.' read -r i_maj i_min _ <<<"$installed"
+  IFS='.' read -r l_maj l_min _ <<<"$latest"
+  i_maj="${i_maj:-0}"; i_min="${i_min:-0}"
+  l_maj="${l_maj:-0}"; l_min="${l_min:-0}"
+  if   (( i_maj < l_maj )); then return 0
+  elif (( i_maj > l_maj )); then return 1
+  elif (( l_min - i_min > 1 )); then return 0
+  else return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# GitHub latest-release lookup (falls back to package.json on main)
+# ---------------------------------------------------------------------------
+
+github_latest() {
+  local repo="$1"
+  local tag
+  tag=$(curl -sf "https://api.github.com/repos/Open-Paws/${repo}/releases/latest" \
+    -H "Accept: application/vnd.github+json" \
+    ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+    | jq -r '.tag_name // empty' 2>/dev/null) || true
+
+  if [[ -z "$tag" ]]; then
+    # No release published — fall back to version in package.json / setup.py on main
+    local pkg_version
+    pkg_version=$(curl -sf "https://api.github.com/repos/Open-Paws/${repo}/contents/package.json" \
+      -H "Accept: application/vnd.github+json" \
+      ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+      | jq -r '.content' 2>/dev/null | base64 -d 2>/dev/null | jq -r '.version // empty' 2>/dev/null) || true
+
+    if [[ -z "$pkg_version" ]]; then
+      pkg_version=$(curl -sf "https://api.github.com/repos/Open-Paws/${repo}/contents/setup.py" \
+        -H "Accept: application/vnd.github+json" \
+        ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+        | jq -r '.content' 2>/dev/null | base64 -d 2>/dev/null \
+        | grep -oP "version\s*=\s*['\"]\\K[^'\"]*" | head -1) || true
+    fi
+
+    tag="${pkg_version:-unknown}"
+  fi
+
+  echo "$tag"
+}
+
+# ---------------------------------------------------------------------------
+# Per-tool version detection
+# ---------------------------------------------------------------------------
+
+installed_eslint_plugin() {
+  npm list eslint-plugin-no-animal-violence --depth=0 2>/dev/null \
+    | grep -oP 'eslint-plugin-no-animal-violence@\K[^\s]+' | head -1 || true
+}
+
+installed_danger_plugin() {
+  npm list danger-plugin-no-animal-violence --depth=0 2>/dev/null \
+    | grep -oP 'danger-plugin-no-animal-violence@\K[^\s]+' | head -1 || true
+}
+
+installed_vscode_extension() {
+  code --list-extensions --show-versions 2>/dev/null \
+    | grep -i 'no-animal-violence' \
+    | grep -oP '@\K[^\s]+' | head -1 || true
+}
+
+installed_pre_commit_hook() {
+  pip show no-animal-violence-pre-commit 2>/dev/null \
+    | grep -i '^Version:' | awk '{print $2}' || true
+}
+
+installed_semgrep_rules() {
+  # Semgrep rules are typically used via a local clone or semgrep registry.
+  # Check for a local clone by looking for the repo directory near CWD.
+  local search_dirs=("." ".." "../semgrep-rules-no-animal-violence" "semgrep-rules-no-animal-violence")
+  for d in "${search_dirs[@]}"; do
+    if [[ -d "$d/.git" ]] && git -C "$d" remote -v 2>/dev/null | grep -q "semgrep-rules-no-animal-violence"; then
+      git -C "$d" describe --tags 2>/dev/null | sed 's/-.*//' || true
+      return
+    fi
+  done
+  echo ""
+}
+
+installed_vale_package() {
+  # Vale packages are not pip/npm — check the .vale.ini for the pinned URL tag.
+  local ini_file
+  ini_file=$(find . -maxdepth 3 -name ".vale.ini" 2>/dev/null | head -1)
+  if [[ -n "$ini_file" ]]; then
+    grep -oP 'no-animal-violence[^/]*/releases/download/\K[^/]+' "$ini_file" | head -1 \
+      || grep -oP 'Speciesism/releases/download/\K[^/]+' "$ini_file" | head -1 \
+      || echo ""
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main check loop
+# ---------------------------------------------------------------------------
+
+declare -A INSTALLED_VERSIONS
+declare -A LATEST_VERSIONS
+declare -A STATUS  # "ok", "outdated", "not_installed", "unknown"
+
+check_tool() {
+  local label="$1"
+  local repo="$2"
+  local installed="$3"
+
+  local latest
+  latest=$(github_latest "$repo")
+  LATEST_VERSIONS["$label"]="$latest"
+
+  if [[ -z "$installed" ]]; then
+    INSTALLED_VERSIONS["$label"]="not installed"
+    STATUS["$label"]="not_installed"
+    return
+  fi
+
+  INSTALLED_VERSIONS["$label"]="$installed"
+
+  if [[ "$latest" == "unknown" ]]; then
+    STATUS["$label"]="unknown"
+    return
+  fi
+
+  if version_gte "$installed" "$latest"; then
+    STATUS["$label"]="ok"
+  elif more_than_one_minor_behind "$installed" "$latest"; then
+    STATUS["$label"]="outdated"
+  else
+    STATUS["$label"]="warn"
+  fi
+}
+
+check_tool "ESLint Plugin"      "eslint-plugin-no-animal-violence"  "$(installed_eslint_plugin)"
+check_tool "VS Code Extension"  "vscode-no-animal-violence"         "$(installed_vscode_extension)"
+check_tool "Semgrep Rules"      "semgrep-rules-no-animal-violence"  "$(installed_semgrep_rules)"
+check_tool "Vale Package"       "vale-no-animal-violence"           "$(installed_vale_package)"
+check_tool "Pre-commit Hook"    "no-animal-violence-pre-commit"     "$(installed_pre_commit_hook)"
+check_tool "GitHub Action"      "no-animal-violence-action"         ""  # CI-only, no local install
+check_tool "Reviewdog Runner"   "reviewdog-no-animal-violence"      ""  # CI-only, no local install
+check_tool "Danger Plugin"      "danger-plugin-no-animal-violence"  "$(installed_danger_plugin)"
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+OUTDATED=0
+
+if $JSON_OUTPUT; then
+  python3 - <<'PYEOF'
+import json, os, sys
+
+tools = [
+  "ESLint Plugin", "VS Code Extension", "Semgrep Rules", "Vale Package",
+  "Pre-commit Hook", "GitHub Action", "Reviewdog Runner", "Danger Plugin"
+]
+
+# Read from environment — bash exports set before calling python
+result = {}
+for t in tools:
+  key = t.replace(" ", "_").upper()
+  result[t] = {
+    "installed": os.environ.get(f"INSTALLED_{key}", ""),
+    "latest":    os.environ.get(f"LATEST_{key}", ""),
+    "status":    os.environ.get(f"STATUS_{key}", ""),
+  }
+print(json.dumps(result, indent=2))
+PYEOF
+else
+  echo ""
+  echo "no-animal-violence tool version check"
+  echo "======================================"
+  printf "%-22s %-18s %-18s %s\n" "Tool" "Installed" "Latest" "Status"
+  printf "%-22s %-18s %-18s %s\n" "----" "---------" "------" "------"
+
+  TOOLS=("ESLint Plugin" "VS Code Extension" "Semgrep Rules" "Vale Package" "Pre-commit Hook" "GitHub Action" "Reviewdog Runner" "Danger Plugin")
+
+  for label in "${TOOLS[@]}"; do
+    installed="${INSTALLED_VERSIONS[$label]}"
+    latest="${LATEST_VERSIONS[$label]}"
+    st="${STATUS[$label]}"
+
+    case "$st" in
+      ok)            status_str="${GREEN}up to date${RESET}" ;;
+      warn)          status_str="${YELLOW}behind (< 1 minor)${RESET}" ;;
+      outdated)      status_str="${RED}OUTDATED (> 1 minor behind)${RESET}"; OUTDATED=1 ;;
+      not_installed) status_str="not installed" ;;
+      *)             status_str="unknown" ;;
+    esac
+
+    printf "%-22s %-18s %-18s %b\n" "$label" "$installed" "$latest" "$status_str"
+  done
+
+  echo ""
+  if (( OUTDATED > 0 )); then
+    echo -e "${RED}One or more tools are outdated. Run the update commands in VERSIONS.md.${RESET}"
+    exit 1
+  else
+    echo -e "${GREEN}All tools up to date.${RESET}"
+    exit 0
+  fi
+fi


### PR DESCRIPTION
## Summary

- Adds `VERSIONS.md` with a compatibility matrix mapping core rules versions to minimum compatible tool versions, a versioning policy (patch/minor/major semantics), per-tool version check one-liners, and update commands for all 8 downstream tools.
- Adds `scripts/check_versions.sh` which detects currently-installed tool versions, compares against latest GitHub releases, warns when a tool is more than one minor version behind, and exits 1 if any tool is outdated.
- Adds `.github/workflows/version-check.yml` which runs on push to main, reports downstream tool versions, and warns if any workflow pins reference an older core rules tag.

Previously there was no mechanism to detect that a stale tool was silently missing new violation categories.

## Test plan
- [ ] `scripts/check_versions.sh` runs without error on a machine with some tools installed
- [ ] `VERSIONS.md` matrix accurately reflects current tool versions (all at 0.1.0, no tagged releases yet)
- [ ] CI workflow triggers on push to main and reports tool versions
- [ ] Script exits 0 when all tools are current, exits 1 when any tool is more than one minor version behind