### PR TITLE
Update CLAUDE.md hierarchy with current strategy context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,70 @@ This is a **mono-repo of rule definitions** for three different inclusive-langua
 | `vale/Speciesism/TechTerminology.yml` | Vale rule: speciesist tech terms |
 | `vale/Speciesism/meta.json` | Vale style package metadata |
 
+## Organizational Context
+
+This repo is the **canonical rule dictionary** for the entire no-animal-violence suite. Every downstream adapter (Vale, ESLint, Semgrep, VS Code, pre-commit, GitHub Action, reviewdog, Danger) consumes or mirrors these definitions. Rule additions here should propagate to all consumers.
+
+**Strategic significance (Lever 1 + Lever 3):** This is a concrete Lever 3 tool — it embeds animal welfare standards into the development process itself. Every developer who installs an adapter becomes aware of speciesist language patterns. The suite is intervention #8 from the 25 Ranked Interventions (Animal-Friendly Data Labelling Standards) made concrete.
+
+**Current org priorities relevant to this repo:**
+- The suite has zero platform presence despite being a shipped product. Planned: bootcamp setup instructions (VS Code extension + pre-commit hook), guild developer onboarding, platform CI. See `ecosystem/integration-todos.md` §27a.
+- Suite maintenance has **no named owner** as of 2026-04-02. The 65+ rules need ongoing false-positive tuning and new term additions — ideal F/E-rank quests in the Guild pipeline.
+- Adoption metrics (npm downloads, VS Code marketplace installs, GitHub Action usage) are not yet tracked. This is a Lever 3 measurement gap.
+- Compassionate Code integration is in place — the CC scanner uses these rules to find speciesist language in open-source repos. Stronger rules here directly improve CC scanner output.
+
+**Decisions affecting this repo:**
+- 2026-03-25: Every repo in the org runs `semgrep --config semgrep-no-animal-violence.yaml` on all code/docs edits as a quality gate.
+- 2026-04-01: The no-animal-violence suite is the model for how shared canonical configs should work org-wide (the external contribution safety pattern should mirror this structure).
+
 ## Related Repos
 
 - [vale-no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) — Standalone Vale distribution package
 - [eslint-plugin-no-animal-violence](https://github.com/Open-Paws/eslint-plugin-no-animal-violence) — ESLint plugin for JS/TS
+- [semgrep-rules-no-animal-violence](https://github.com/Open-Paws/semgrep-rules-no-animal-violence) — Semgrep rules
+- [vscode-no-animal-violence](https://github.com/Open-Paws/vscode-no-animal-violence) — VS Code extension
+- [no-animal-violence-action](https://github.com/Open-Paws/no-animal-violence-action) — GitHub Action
+- [no-animal-violence-pre-commit](https://github.com/Open-Paws/no-animal-violence-pre-commit) — pre-commit hook
+- [reviewdog-no-animal-violence](https://github.com/Open-Paws/reviewdog-no-animal-violence) — reviewdog runner
+- [danger-plugin-no-animal-violence](https://github.com/Open-Paws/danger-plugin-no-animal-violence) — Danger.js plugin
+
+## Development Standards
+
+### 10-Point Review Checklist (ranked by AI violation frequency)
+
+1. **DRY** — AI clones rule patterns at 4x the human rate. Search existing rules before adding new ones.
+2. **Deep modules** — Each rule file covers one category cleanly. No mixed concerns (idioms + tech terms in one file).
+3. **Single responsibility** — One rule entry = one pattern. Don't bundle multiple phrases into a single regex.
+4. **Error handling** — Validate YAML structure; fail explicitly on malformed rule files rather than silently skipping.
+5. **Information hiding** — Rule files expose patterns and alternatives, not internal implementation details of consumers.
+6. **Ubiquitous language** — Use movement terminology: "farmed animal" not "livestock," "factory farm" not "farm." Never introduce synonyms for domain terms.
+7. **Design for change** — Rules should be addable/removable without restructuring the file. Each consumer embeds these patterns inline — changes require downstream propagation checks.
+8. **Legacy velocity** — Before modifying existing rules, verify no downstream consumer breaks. Pre-commit and CI action embed patterns inline.
+9. **Over-patterning** — A flat list of patterns is better than a complex inheritance hierarchy. Keep rule files simple.
+10. **Test quality** — New rules must include both a true-positive example (what gets flagged) and a false-positive suppression example (what should not get flagged).
+
+### Quality Gates
+
+- **Desloppify**: `desloppify scan --path .` — minimum score ≥85.
+- **Self-check**: Run the rules against this repo's own documentation to catch accidental violations in comments or descriptions.
+- **Two-failure rule**: After two failed fixes on the same problem, stop and restart with a better approach.
+
+### Testing Methodology
+
+- Spec-first: define what a new rule catches (and what it does not) before writing the YAML.
+- Every rule must have at least one true-positive example and one false-positive suppression example.
+- Three questions per rule: (1) Does it catch the target phrase? (2) Does it avoid flagging legitimate uses (POSIX `kill()`, `git master`, quotations, proper nouns)? (3) Is the suggested alternative genuinely better?
+
+### Seven Concerns — Repo-Specific Notes
+
+1. **Testing** — Rule files need example-based tests. Currently underspecified; this is a known gap.
+2. **Security** — Context suppression logic (for POSIX calls, system terms) must be audited to avoid silently suppressing legitimate security-relevant patterns.
+3. **Privacy** — Not applicable to this repo.
+4. **Cost optimization** — Static files, no compute costs. Rule additions are free.
+5. **Advocacy domain** — This is the canonical dictionary. Every term must use movement-standard language. Never introduce euphemisms for exploitation.
+6. **Accessibility** — Rule suggestions must be in plain English accessible to non-native speakers.
+7. **Emotional safety** — Rule descriptions should explain *why* a phrase is problematic without exposing developers to graphic content.
+
+### Structured Coding Reference
+
+For tool-specific AI coding instructions (Claude Code rules, Cursor MDC, Copilot, Windsurf, etc.), copy the corresponding directory from `structured-coding-with-ai` into this project root.


### PR DESCRIPTION
## Summary
- Updated root CLAUDE.md with current organizational context (strategy as of 2026-04-02)
- Added `## Organizational Context` section: strategic role (Lever 1+3 canonical dictionary), current priorities, and decisions affecting this repo
- Added `## Development Standards` section: 10-point review checklist, quality gates (desloppify ≥85, self-check), testing methodology, seven concerns with repo-specific notes
- Added complete related-repos list covering all 9 suite adapters
- No existing build/test/deploy commands modified

## Files changed
- `CLAUDE.md` — updated (root)

Generated by /generate-context skill from open-paws-strategy