### PR TITLE
feat: rule audit — 15 new patterns + false-positive refinements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ This is a **mono-repo of rule definitions** for three different inclusive-langua
 | `woke/.woke.yaml` | woke scanner config with all speciesist patterns |
 | `alex/animal-violence.yml` | alex/retext-equality rules for violent idioms |
 | `alex/speciesism.yml` | alex/retext-equality rules for speciesist metaphors |
+| `alex/industry-euphemisms.yml` | alex/retext-equality rules for industry euphemisms (free-range, cage-free, harvest) |
 | `vale/Speciesism/AnimalIdioms.yml` | Vale rule: violent animal idioms |
 | `vale/Speciesism/AnimalMetaphors.yml` | Vale rule: animal-as-object metaphors |
 | `vale/Speciesism/TechTerminology.yml` | Vale rule: speciesist tech terms |

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -469,6 +469,18 @@ branch = "origin/master"
 
 `red herring` is flagged at `info` level (suggestion only, not blocking). In prose-heavy repos, you can lower the `MinAlertLevel` in `.vale.ini` to `warning` to suppress suggestion-level findings.
 
+**"weasel words" in linguistics or copy-editing docs**
+
+`weasel words` is flagged at `warning`. In docs that explicitly discuss the rhetorical concept (e.g., a guide to clear writing), suppress with an inline comment.
+
+**"cold turkey" in health or addiction-treatment contexts**
+
+`cold turkey` is flagged at `info` level. When documenting medical or harm-reduction topics where the phrase is the standard clinical shorthand, suppress with an inline comment.
+
+**"pest control" in software tooling names**
+
+`pest control` is flagged at `info` level. If your project integrates a third-party tool that uses this phrase in its official name, suppress with an inline comment on that specific reference rather than disabling the rule globally.
+
 ### Incremental Adoption
 
 If your existing codebase has many matches, adopt incrementally without blocking your team:

--- a/alex/industry-euphemisms.yml
+++ b/alex/industry-euphemisms.yml
@@ -1,0 +1,67 @@
+# Industry euphemism patterns for retext-equality / alex
+# Category: industry-euphemism
+#
+# These patterns detect welfare-washing language and agricultural euphemisms
+# that obscure the reality of animal exploitation. Alternatives are factually
+# accurate and consistent with movement-standard terminology.
+#
+# This file covers three euphemism categories extracted from speciesism.yml
+# to maintain clean category separation (one file = one concern).
+#
+# Academic sources:
+# - Hagendorff, Bossert, Tse & Singer (2023), "Speciesist bias in AI", AI and Ethics
+
+# === Harvest / Kill Euphemisms ===
+
+- type: basic
+  note: >-
+    Applies agricultural crop-harvest framing to killing animals. 'Harvesting'
+    obscures that living beings are being killed. Alternatives align with
+    Vale's IndustryEuphemisms suggestions for cross-tool consistency.
+  # true-positive:  "The report described harvesting animals as an efficient process."
+  # false-positive: "The fruit harvest attracted workers from across the region." (crop harvest — not animals)
+  considerate:
+    killing animals: a
+    catching and killing fish: a
+    catching fish: a
+  inconsiderate:
+    harvesting animals: industry-euphemism
+    harvest animals: industry-euphemism
+    fish harvest: industry-euphemism
+    harvesting fish: industry-euphemism
+
+# === Free-Range Welfare-Washing ===
+
+- type: basic
+  note: >-
+    Welfare-washing: 'free-range' implies humane conditions but still involves
+    confinement, forced reproduction, and slaughter. Use only when quoting
+    certification standards directly; otherwise describe actual conditions.
+  # true-positive:  "The supermarket stocks free-range eggs alongside conventional ones."
+  # false-positive: "The certification body defines 'free-range' as requiring 4 sq ft of outdoor space per bird." (quoting a standard directly)
+  considerate:
+    eggs from hens with outdoor access: a
+    chicken with outdoor access: a
+  inconsiderate:
+    free-range eggs: industry-euphemism
+    free range eggs: industry-euphemism
+    free-range chicken: industry-euphemism
+    free range chicken: industry-euphemism
+
+# === Cage-Free Welfare-Washing ===
+
+- type: basic
+  note: >-
+    Welfare-washing: 'cage-free' implies humane conditions but hens may still
+    be confined at high density indoors. Use only when quoting certification
+    standards directly; otherwise describe actual conditions.
+  # true-positive:  "The company pledged to source only cage-free eggs by 2025."
+  # false-positive: "Under USDA 'cage-free' certification, hens must have unlimited access to food and water." (quoting a standard directly)
+  considerate:
+    eggs from uncaged hens: a
+    hens without cages: a
+  inconsiderate:
+    cage-free eggs: industry-euphemism
+    cage free eggs: industry-euphemism
+    cage-free hens: industry-euphemism
+    cage free hens: industry-euphemism

--- a/alex/speciesism.yml
+++ b/alex/speciesism.yml
@@ -252,6 +252,8 @@
   note: >-
     This phrase uses a predator-prey relationship as the archetype of deception.
     Alternatives describe the concept directly without animal framing.
+  # true-positive:  "Be alert — that consultant is a wolf in sheep's clothing."
+  # false-positive: "The fable 'Wolf in Sheep's Clothing' is quoted verbatim here."
   considerate:
     deceptive actor: a
     bad actor in disguise: a
@@ -264,6 +266,8 @@
   note: >-
     This phrase references trading horses as commodities. Alternatives describe
     the negotiation pattern without the animal framing.
+  # true-positive:  "The bill passed only after extensive horse trading between parties."
+  # false-positive: "The historical practice of horse trading was regulated by medieval guilds."
   considerate:
     political bargaining: a
     transactional negotiation: a
@@ -276,6 +280,8 @@
   note: >-
     This phrase uses a snake as a metaphor for treachery. Alternatives describe
     the threat directly.
+  # true-positive:  "Watch out for him — he is a real snake in the grass."
+  # false-positive: "The grass snake is a non-venomous species found across Europe."
   considerate:
     hidden threat: a
     concealed adversary: a
@@ -286,7 +292,11 @@
 - type: basic
   note: >-
     This phrase uses a weasel as a metaphor for evasiveness. Alternatives
-    describe the language problem precisely.
+    describe the language problem precisely. False positive: linguistics or
+    copy-editing docs that discuss the rhetorical concept by name — suppress
+    with an inline comment in those contexts.
+  # true-positive:  "The policy document is full of weasel words like 'may' and 'considers'."
+  # false-positive: "The term 'weasel words' was coined by Theodore Roosevelt in 1916." (discussing the concept)
   considerate:
     deliberately vague language: a
     evasive language: a
@@ -299,6 +309,8 @@
   note: >-
     This phrase references a predator killing farmed birds to describe conflicted
     oversight. Alternatives describe the structural conflict directly.
+  # true-positive:  "Letting the industry self-regulate is like the fox guarding the henhouse."
+  # false-positive: "The farmer built a fence after a fox got into the henhouse last winter."
   considerate:
     conflicted oversight: a
     self-interested regulator: a
@@ -309,7 +321,11 @@
 - type: basic
   note: >-
     This phrase references slaughtered and chilled poultry to describe abrupt
-    cessation. Alternatives describe the action directly.
+    cessation. Alternatives describe the action directly. False positive: medical
+    or addiction-treatment documentation where the phrase is standard clinical
+    shorthand — suppress with an inline comment in those contexts.
+  # true-positive:  "He decided to quit social media cold turkey."
+  # false-positive: "The harm-reduction guide advises against quitting cold turkey without medical support." (clinical context)
   considerate:
     abrupt cessation: a
     stop immediately: a
@@ -322,6 +338,8 @@
   note: >-
     This phrase references stealing a goat. Alternatives describe the irritation
     directly.
+  # true-positive:  "Slow CI pipelines really get my goat."
+  # false-positive: "The sanctuary volunteer said the goat gets your full attention the moment you enter."
   considerate:
     annoy you: a
     irritate you: a
@@ -335,6 +353,8 @@
   note: >-
     This phrase references farmed cattle returning from pasture. Alternatives
     communicate the indefinite timeframe directly.
+  # true-positive:  "We could debate this until the cows come home and still not agree."
+  # false-positive: "The cows come home at dusk and the farmer closes the gate." (literal farming description)
   considerate:
     indefinitely: a
     for a very long time: a
@@ -346,6 +366,8 @@
   note: >-
     This phrase references farm animals in an implausibility idiom. Alternatives
     describe the deception without the animal framing.
+  # true-positive:  "The vendor's explanation was a complete cock-and-bull story."
+  # false-positive: "The village pub sign depicts a cock and bull as its historical emblem." (proper noun / literal)
   considerate:
     fabricated story: a
     implausible claim: a
@@ -358,6 +380,8 @@
   note: >-
     Variant of 'throw someone to the wolves' — also covers the form without
     an explicit pronoun.
+  # true-positive:  "The manager threw the junior developer to the wolves at the client meeting."
+  # false-positive: "In the documentary, researchers throw food to the wolves to observe pack hierarchy." (literal wildlife)
   considerate:
     abandon to criticism: a
     leave to face hostility alone: a
@@ -369,52 +393,13 @@
   note: >-
     Standalone variant of 'there are bigger fish to fry' — catches the shortened
     form used in technical writing.
+  # true-positive:  "Don't get stuck on this edge case — we have bigger fish to fry."
+  # false-positive: "The chef said the bigger fish to fry requires a wider pan." (literal cooking context)
   considerate:
     more important matters to address: a
     higher priorities: a
   inconsiderate:
     bigger fish to fry: speciesism
 
-# === Industry Euphemisms ===
-
-- type: basic
-  note: >-
-    Applies agricultural crop-harvest framing to killing animals. 'Harvesting'
-    obscures that living beings are being killed.
-  considerate:
-    catching fish: a
-    fishing: a
-    taking animals: a
-  inconsiderate:
-    harvesting animals: industry-euphemism
-    harvest animals: industry-euphemism
-    fish harvest: industry-euphemism
-    harvesting fish: industry-euphemism
-
-- type: basic
-  note: >-
-    Welfare-washing: 'free-range' implies humane conditions but still involves
-    confinement and slaughter. Use only when quoting certification standards
-    directly; otherwise describe actual conditions.
-  considerate:
-    eggs from hens with outdoor access: a
-    chicken with outdoor access: a
-  inconsiderate:
-    free-range eggs: industry-euphemism
-    free range eggs: industry-euphemism
-    free-range chicken: industry-euphemism
-    free range chicken: industry-euphemism
-
-- type: basic
-  note: >-
-    Welfare-washing: 'cage-free' implies humane conditions but hens may still
-    be confined at high density indoors. Use only when quoting certification
-    standards directly; otherwise describe actual conditions.
-  considerate:
-    eggs from uncaged hens: a
-    hens without cages: a
-  inconsiderate:
-    cage-free eggs: industry-euphemism
-    cage free eggs: industry-euphemism
-    cage-free hens: industry-euphemism
-    cage free hens: industry-euphemism
+# Industry euphemism rules (harvesting, free-range, cage-free) have been
+# extracted to alex/industry-euphemisms.yml for clean category separation.

--- a/alex/speciesism.yml
+++ b/alex/speciesism.yml
@@ -247,3 +247,174 @@
     dogfooding: speciesism
     eating your own dogfood: speciesism
     eat your own dogfood: speciesism
+
+- type: basic
+  note: >-
+    This phrase uses a predator-prey relationship as the archetype of deception.
+    Alternatives describe the concept directly without animal framing.
+  considerate:
+    deceptive actor: a
+    bad actor in disguise: a
+    hidden threat: a
+  inconsiderate:
+    wolf in sheep's clothing: speciesism
+    wolves in sheep's clothing: speciesism
+
+- type: basic
+  note: >-
+    This phrase references trading horses as commodities. Alternatives describe
+    the negotiation pattern without the animal framing.
+  considerate:
+    political bargaining: a
+    transactional negotiation: a
+    trading favors: a
+  inconsiderate:
+    horse trading: speciesism
+    horse-trading: speciesism
+
+- type: basic
+  note: >-
+    This phrase uses a snake as a metaphor for treachery. Alternatives describe
+    the threat directly.
+  considerate:
+    hidden threat: a
+    concealed adversary: a
+    lurking danger: a
+  inconsiderate:
+    snake in the grass: speciesism
+
+- type: basic
+  note: >-
+    This phrase uses a weasel as a metaphor for evasiveness. Alternatives
+    describe the language problem precisely.
+  considerate:
+    deliberately vague language: a
+    evasive language: a
+    non-committal phrasing: a
+  inconsiderate:
+    weasel words: speciesism
+    weasel word: speciesism
+
+- type: basic
+  note: >-
+    This phrase references a predator killing farmed birds to describe conflicted
+    oversight. Alternatives describe the structural conflict directly.
+  considerate:
+    conflicted oversight: a
+    self-interested regulator: a
+  inconsiderate:
+    fox guarding the henhouse: speciesism
+    fox in the henhouse: speciesism
+
+- type: basic
+  note: >-
+    This phrase references slaughtered and chilled poultry to describe abrupt
+    cessation. Alternatives describe the action directly.
+  considerate:
+    abrupt cessation: a
+    stop immediately: a
+    quit all at once: a
+  inconsiderate:
+    cold turkey: speciesism
+    go cold turkey: speciesism
+
+- type: basic
+  note: >-
+    This phrase references stealing a goat. Alternatives describe the irritation
+    directly.
+  considerate:
+    annoy you: a
+    irritate you: a
+    get under your skin: a
+  inconsiderate:
+    get your goat: speciesism
+    get my goat: speciesism
+    got my goat: speciesism
+
+- type: basic
+  note: >-
+    This phrase references farmed cattle returning from pasture. Alternatives
+    communicate the indefinite timeframe directly.
+  considerate:
+    indefinitely: a
+    for a very long time: a
+    without end: a
+  inconsiderate:
+    until the cows come home: speciesism
+
+- type: basic
+  note: >-
+    This phrase references farm animals in an implausibility idiom. Alternatives
+    describe the deception without the animal framing.
+  considerate:
+    fabricated story: a
+    implausible claim: a
+    tall tale: a
+  inconsiderate:
+    cock-and-bull story: speciesism
+    cock and bull story: speciesism
+
+- type: basic
+  note: >-
+    Variant of 'throw someone to the wolves' — also covers the form without
+    an explicit pronoun.
+  considerate:
+    abandon to criticism: a
+    leave to face hostility alone: a
+  inconsiderate:
+    throw to the wolves: speciesism
+    thrown to the wolves: speciesism
+
+- type: basic
+  note: >-
+    Standalone variant of 'there are bigger fish to fry' — catches the shortened
+    form used in technical writing.
+  considerate:
+    more important matters to address: a
+    higher priorities: a
+  inconsiderate:
+    bigger fish to fry: speciesism
+
+# === Industry Euphemisms ===
+
+- type: basic
+  note: >-
+    Applies agricultural crop-harvest framing to killing animals. 'Harvesting'
+    obscures that living beings are being killed.
+  considerate:
+    catching fish: a
+    fishing: a
+    taking animals: a
+  inconsiderate:
+    harvesting animals: industry-euphemism
+    harvest animals: industry-euphemism
+    fish harvest: industry-euphemism
+    harvesting fish: industry-euphemism
+
+- type: basic
+  note: >-
+    Welfare-washing: 'free-range' implies humane conditions but still involves
+    confinement and slaughter. Use only when quoting certification standards
+    directly; otherwise describe actual conditions.
+  considerate:
+    eggs from hens with outdoor access: a
+    chicken with outdoor access: a
+  inconsiderate:
+    free-range eggs: industry-euphemism
+    free range eggs: industry-euphemism
+    free-range chicken: industry-euphemism
+    free range chicken: industry-euphemism
+
+- type: basic
+  note: >-
+    Welfare-washing: 'cage-free' implies humane conditions but hens may still
+    be confined at high density indoors. Use only when quoting certification
+    standards directly; otherwise describe actual conditions.
+  considerate:
+    eggs from uncaged hens: a
+    hens without cages: a
+  inconsiderate:
+    cage-free eggs: industry-euphemism
+    cage free eggs: industry-euphemism
+    cage-free hens: industry-euphemism
+    cage free hens: industry-euphemism

--- a/vale/Speciesism/AnimalIdioms.yml
+++ b/vale/Speciesism/AnimalIdioms.yml
@@ -4,6 +4,7 @@ link: https://doi.org/10.1007/s43681-023-00380-w
 level: warning
 ignorecase: true
 swap:
+  # --- Existing rules (pre-PR) ---
   'kill two birds with one stone': accomplish two things at once
   'killing two birds with one stone': accomplishing two things at once
   'killed two birds with one stone': accomplished two things at once
@@ -30,23 +31,60 @@ swap:
   'from the horse''s mouth': from a reliable source
   'whack-a-mole': recurring problem
   'whack a mole': recurring problem
+  # --- New rules added in PR #16 ---
+  # wolf in sheep's clothing
+  #   true-positive:  "That vendor is a wolf in sheep's clothing — all promises, no delivery."
+  #   false-positive: "Aesop's fable 'The Wolf in Sheep's Clothing' is referenced by name here." (title / direct quotation)
   'wolf in sheep''s clothing': deceptive actor
   'wolves in sheep''s clothing': deceptive actors
+  # horse trading
+  #   true-positive:  "The budget was approved only after significant horse trading."
+  #   false-positive: "Horse trading was a common practice at medieval markets." (historical / literal context)
   'horse trading': political bargaining
   'horse-trading': political bargaining
+  # gorilla in the room
+  #   true-positive:  "Nobody mentioned the gorilla in the room — the project is massively over budget."
+  #   false-positive: "The gorilla in the room at the zoo attracted large crowds." (literal animal reference)
   'gorilla in the room': the obvious issue
+  # snake in the grass
+  #   true-positive:  "Don't trust him — he's a snake in the grass."
+  #   false-positive: "A grass snake is a harmless, non-venomous reptile." (literal species description)
   'snake in the grass': hidden threat
+  # fox guarding the henhouse
+  #   true-positive:  "Having the regulator funded by the industry is like the fox guarding the henhouse."
+  #   false-positive: "The farmer added electric fencing after a fox got into the henhouse." (literal agricultural context)
   'fox guarding the henhouse': conflicted oversight
   'fox in the henhouse': conflicted oversight
+  # cold turkey
+  #   true-positive:  "She quit caffeine cold turkey and had withdrawal headaches for a week."
+  #   false-positive: "The harm-reduction clinic advises against stopping cold turkey without medical supervision." (clinical context — suppress)
   'cold turkey': abrupt cessation
   'go cold turkey': stop immediately
+  # get your goat
+  #   true-positive:  "Merge conflicts late on Friday really get my goat."
+  #   false-positive: "The sanctuary said the goat gets your attention the moment you enter the pen." (literal animal interaction)
   'get your goat': annoy you
   'get my goat': annoy me
   'got my goat': annoyed me
+  # until the cows come home
+  #   true-positive:  "We could argue about tabs vs. spaces until the cows come home."
+  #   false-positive: "The cows come home each evening when the farmer sounds the bell." (literal farming description)
   'until the cows come home': indefinitely
+  # cock-and-bull story
+  #   true-positive:  "The contractor fed us a cock-and-bull story about why the deadline slipped."
+  #   false-positive: "The Cock and Bull is the name of the village pub on the high street." (proper noun)
   'cock-and-bull story': fabricated story
   'cock and bull story': fabricated story
+  # throw to the wolves
+  #   true-positive:  "They threw the junior dev to the wolves at the client postmortem."
+  #   false-positive: "Wildlife researchers throw food to the wolves to study pack feeding order." (literal wildlife research)
   'throw to the wolves': abandon to criticism
   'thrown to the wolves': abandoned to criticism
+  # bigger fish to fry
+  #   true-positive:  "Let's not get distracted by this — there are bigger fish to fry."
+  #   false-positive: "The fishmonger said the bigger fish to fry needed a wider pan." (literal cooking context)
   'bigger fish to fry': more important matters to address
+  # open season on
+  #   true-positive:  "After the CTO's resignation it was open season on the engineering team."
+  #   false-positive: "Opening season for the conference begins in March." (conference scheduling — scoped by "open season on" term)
   'open season on': free-for-all targeting

--- a/vale/Speciesism/AnimalIdioms.yml
+++ b/vale/Speciesism/AnimalIdioms.yml
@@ -30,3 +30,23 @@ swap:
   'from the horse''s mouth': from a reliable source
   'whack-a-mole': recurring problem
   'whack a mole': recurring problem
+  'wolf in sheep''s clothing': deceptive actor
+  'wolves in sheep''s clothing': deceptive actors
+  'horse trading': political bargaining
+  'horse-trading': political bargaining
+  'gorilla in the room': the obvious issue
+  'snake in the grass': hidden threat
+  'fox guarding the henhouse': conflicted oversight
+  'fox in the henhouse': conflicted oversight
+  'cold turkey': abrupt cessation
+  'go cold turkey': stop immediately
+  'get your goat': annoy you
+  'get my goat': annoy me
+  'got my goat': annoyed me
+  'until the cows come home': indefinitely
+  'cock-and-bull story': fabricated story
+  'cock and bull story': fabricated story
+  'throw to the wolves': abandon to criticism
+  'thrown to the wolves': abandoned to criticism
+  'bigger fish to fry': more important matters to address
+  'open season on': free-for-all targeting

--- a/vale/Speciesism/AnimalMetaphors.yml
+++ b/vale/Speciesism/AnimalMetaphors.yml
@@ -12,3 +12,5 @@ swap:
   'dog eat dog': ruthlessly competitive
   'rat race': competitive grind
   'red herring': false lead
+  'weasel words': deliberately vague language
+  'weasel word': deliberately vague language

--- a/vale/Speciesism/AnimalMetaphors.yml
+++ b/vale/Speciesism/AnimalMetaphors.yml
@@ -12,5 +12,8 @@ swap:
   'dog eat dog': ruthlessly competitive
   'rat race': competitive grind
   'red herring': false lead
+  # weasel words / weasel word (new in PR #16)
+  #   true-positive:  "The policy document is full of weasel words like 'may' and 'endeavours to'."
+  #   false-positive: "Theodore Roosevelt coined the term 'weasel words' in a 1916 speech." (discussing the rhetorical concept by name — suppress with inline comment)
   'weasel words': deliberately vague language
   'weasel word': deliberately vague language

--- a/vale/Speciesism/IndustryEuphemisms.yml
+++ b/vale/Speciesism/IndustryEuphemisms.yml
@@ -29,3 +29,15 @@ swap:
   'humanely killed': killed
   'broiler': chicken raised for meat
   'broilers': chickens raised for meat
+  'harvesting animals': killing animals
+  'harvest animals': kill animals
+  'fish harvest': fish killing
+  'harvesting fish': catching and killing fish
+  'free-range eggs': eggs from hens with outdoor access
+  'free range eggs': eggs from hens with outdoor access
+  'free-range chicken': chicken with outdoor access
+  'free range chicken': chicken with outdoor access
+  'cage-free eggs': eggs from uncaged hens
+  'cage free eggs': eggs from uncaged hens
+  'cage-free hens': uncaged hens
+  'cage free hens': uncaged hens

--- a/vale/Speciesism/IndustryEuphemisms.yml
+++ b/vale/Speciesism/IndustryEuphemisms.yml
@@ -29,15 +29,32 @@ swap:
   'humanely killed': killed
   'broiler': chicken raised for meat
   'broilers': chickens raised for meat
+  # harvest / kill euphemisms (new in PR #16)
+  #   true-positive:  "The report described harvesting animals as an efficient production process."
+  #   false-positive: "The apple harvest this autumn was the largest in a decade." (crop harvest — not animals)
   'harvesting animals': killing animals
   'harvest animals': kill animals
+  #   true-positive:  "The fishing industry's fish harvest totalled 80 million tonnes last year."
+  #   false-positive: "The harvest festival celebrated the community's grain and vegetable yield." (crop harvest — not fish)
   'fish harvest': fish killing
+  #   true-positive:  "They discussed harvesting fish more 'sustainably' without addressing mortality."
+  #   false-positive: "Harvesting rainwater helps farms reduce reliance on groundwater." (water — not animals)
   'harvesting fish': catching and killing fish
+  # free-range welfare-washing (new in PR #16)
+  #   true-positive:  "The menu proudly lists free-range eggs from a certified farm."
+  #   false-positive: "The RSPCA Assured standard defines 'free-range eggs' as requiring 4 m² of outdoor range per hen." (quoting a certification standard directly — suppress)
   'free-range eggs': eggs from hens with outdoor access
   'free range eggs': eggs from hens with outdoor access
+  #   true-positive:  "Consumers are willing to pay more for free-range chicken."
+  #   false-positive: "The Soil Association's 'free-range chicken' certification requires year-round outdoor access." (quoting a certification standard directly — suppress)
   'free-range chicken': chicken with outdoor access
   'free range chicken': chicken with outdoor access
+  # cage-free welfare-washing (new in PR #16)
+  #   true-positive:  "The company pledged to source only cage-free eggs by 2025."
+  #   false-positive: "The USDA defines 'cage-free eggs' as eggs from hens able to roam freely in a building." (quoting a certification standard directly — suppress)
   'cage-free eggs': eggs from uncaged hens
   'cage free eggs': eggs from uncaged hens
+  #   true-positive:  "The farm houses thousands of cage-free hens in a single barn."
+  #   false-positive: "Under EU Directive 1999/74/EC, cage-free hens must have access to litter, perches, and nest boxes." (quoting legislation directly — suppress)
   'cage-free hens': uncaged hens
   'cage free hens': uncaged hens

--- a/woke/.woke.yaml
+++ b/woke/.woke.yaml
@@ -113,9 +113,10 @@ rules:
     word_boundary: false
     categories:
     - animal-violence
-- name: there-are-bigger-fish-to-fry
+- name: bigger-fish-to-fry
   terms:
   - there are bigger fish to fry
+  - bigger fish to fry
   alternatives:
   - more important matters to address
   - higher priorities
@@ -291,6 +292,9 @@ rules:
   - throw someone to the wolves
   - throwing someone to the wolves
   - threw someone to the wolves
+  - throw to the wolves
+  - throwing to the wolves
+  - thrown to the wolves
   alternatives:
   - abandon to criticism
   - leave to face hostility alone
@@ -853,17 +857,15 @@ rules:
     - animal-violence
 - name: open-season
   terms:
-  - open season
-  - opening season
-  - opened season
+  - open season on
   alternatives:
-  - free-for-all
-  - unrestricted criticism
-  - no holds barred
+  - free-for-all targeting
+  - unrestricted criticism of
+  - no holds barred against
   severity: warning
-  note: References hunting season — the legal period for killing animals
+  note: References hunting season — the legal period for killing animals. Scoped to "open season on [something]" to avoid false positives on "opening season" (sports/conferences) and "open season tickets".
   options:
-    word_boundary: true
+    word_boundary: false
     categories:
     - animal-violence
 - name: put-out-to-pasture
@@ -958,7 +960,7 @@ rules:
   - trim
   - filter out
   severity: warning
-  note: Euphemism for mass killing of animals — used in wildlife management and farming
+  note: Euphemism for mass killing of animals — used in wildlife management and farming. Known false positive in data pipeline code where "cull" means remove duplicates or trim a collection; suppress with inline comment in those contexts.
   options:
     word_boundary: true
     categories:
@@ -1002,3 +1004,209 @@ rules:
     word_boundary: true
     categories:
     - animal-violence
+- name: wolf-in-sheeps-clothing
+  terms:
+  - wolf in sheep's clothing
+  - wolves in sheep's clothing
+  - wolf in sheeps clothing
+  alternatives:
+  - deceptive actor
+  - bad actor in disguise
+  - hidden threat
+  severity: warning
+  note: Frames a predator-prey relationship as the archetype of deception — alternatives describe the concept directly
+  options:
+    word_boundary: false
+    categories:
+    - animal-violence
+- name: horse-trading
+  terms:
+  - horse trading
+  - horse-trading
+  alternatives:
+  - political bargaining
+  - transactional negotiation
+  - trading favors
+  severity: info
+  note: References trading horses as commodities — alternatives describe the negotiation pattern without the animal framing
+  options:
+    word_boundary: true
+    categories:
+    - animal-violence
+- name: gorilla-in-the-room
+  terms:
+  - gorilla in the room
+  alternatives:
+  - the obvious issue
+  - the unaddressed problem
+  severity: info
+  note: Variant of "elephant in the room" — flag for awareness only
+  options:
+    word_boundary: false
+    categories:
+    - animal-violence
+- name: snake-in-the-grass
+  terms:
+  - snake in the grass
+  alternatives:
+  - hidden threat
+  - concealed adversary
+  - lurking danger
+  severity: warning
+  note: Uses a snake as a metaphor for treachery — alternatives describe the threat directly
+  options:
+    word_boundary: false
+    categories:
+    - animal-violence
+- name: weasel-words
+  terms:
+  - weasel words
+  - weasel word
+  alternatives:
+  - deliberately vague language
+  - evasive language
+  - non-committal phrasing
+  severity: warning
+  note: Uses a weasel as a metaphor for evasiveness — alternatives describe the language problem precisely
+  options:
+    word_boundary: true
+    categories:
+    - animal-violence
+- name: fox-guarding-the-henhouse
+  terms:
+  - fox guarding the henhouse
+  - fox in the henhouse
+  - fox watching the henhouse
+  alternatives:
+  - conflicted oversight
+  - self-interested regulator
+  - the regulated watching the regulators
+  severity: warning
+  note: References a predator killing farmed birds — alternatives describe the structural conflict directly
+  options:
+    word_boundary: false
+    categories:
+    - animal-violence
+- name: cold-turkey
+  terms:
+  - cold turkey
+  - go cold turkey
+  - went cold turkey
+  - going cold turkey
+  alternatives:
+  - abrupt cessation
+  - stop immediately
+  - quit all at once
+  severity: info
+  note: References slaughtered and chilled poultry — alternatives describe the abrupt cessation directly
+  options:
+    word_boundary: false
+    categories:
+    - animal-violence
+- name: get-your-goat
+  terms:
+  - get your goat
+  - get my goat
+  - got my goat
+  - got your goat
+  - getting your goat
+  alternatives:
+  - annoy you
+  - irritate you
+  - get under your skin
+  severity: info
+  note: References stealing a goat to unsettle a competitor — alternatives describe the irritation directly
+  options:
+    word_boundary: false
+    categories:
+    - animal-violence
+- name: until-the-cows-come-home
+  terms:
+  - until the cows come home
+  alternatives:
+  - indefinitely
+  - for a very long time
+  - without end
+  severity: info
+  note: References farmed cattle returning from pasture — alternatives communicate the indefinite timeframe directly
+  options:
+    word_boundary: false
+    categories:
+    - animal-violence
+- name: cock-and-bull-story
+  terms:
+  - cock-and-bull story
+  - cock and bull story
+  alternatives:
+  - fabricated story
+  - implausible claim
+  - tall tale
+  severity: warning
+  note: References farm animals in an implausibility idiom — alternatives describe the deception without the animal framing
+  options:
+    word_boundary: false
+    categories:
+    - animal-violence
+- name: harvest-animals
+  terms:
+  - harvesting animals
+  - harvest animals
+  - animal harvest
+  - fish harvest
+  - harvesting fish
+  - shrimp harvest
+  - harvesting shrimp
+  alternatives:
+  - catching fish
+  - fishing
+  - taking animals
+  severity: warning
+  note: Industry euphemism applying agricultural crop-harvest framing to killing animals — "harvesting" obscures that living beings are being killed
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+- name: free-range-welfare-washing
+  terms:
+  - free-range eggs
+  - free range eggs
+  - free-range chicken
+  - free range chicken
+  alternatives:
+  - eggs from hens with outdoor access
+  - chicken with outdoor access
+  severity: info
+  note: 'Welfare-washing: "free-range" implies humane conditions but still involves confinement, forced reproduction, and slaughter. Use only when quoting certification standards directly; otherwise describe actual conditions.'
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+- name: cage-free-welfare-washing
+  terms:
+  - cage-free eggs
+  - cage free eggs
+  - cage-free hens
+  - cage free hens
+  alternatives:
+  - eggs from uncaged hens
+  - hens without cages
+  severity: info
+  note: 'Welfare-washing: "cage-free" implies humane conditions but hens may still be confined at high density indoors. Use only when quoting certification standards directly; otherwise describe actual conditions.'
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+- name: pest-control-mass-killing
+  terms:
+  - pest control
+  - pest management
+  alternatives:
+  - rodent deterrence
+  - rodent exclusion
+  - animal deterrence
+  severity: info
+  note: Framing animals as "pests" devalues their lives and normalizes mass killing. In code contexts (e.g., variable names, config files for rodent detection systems), suppress with inline comment if referring to a specific software tool name.
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism

--- a/woke/.woke.yaml
+++ b/woke/.woke.yaml
@@ -1004,6 +1004,8 @@ rules:
     word_boundary: true
     categories:
     - animal-violence
+# true-positive:  "Be wary — that consultant is a wolf in sheep's clothing."
+# false-positive: "The fable 'Wolf in Sheep's Clothing' is referenced by its exact title." (direct title quotation)
 - name: wolf-in-sheeps-clothing
   terms:
   - wolf in sheep's clothing
@@ -1019,6 +1021,8 @@ rules:
     word_boundary: false
     categories:
     - animal-violence
+# true-positive:  "The legislation passed only after extensive horse trading between caucuses."
+# false-positive: "Horse trading was a common feature of medieval country fairs." (historical / literal context)
 - name: horse-trading
   terms:
   - horse trading
@@ -1033,6 +1037,8 @@ rules:
     word_boundary: true
     categories:
     - animal-violence
+# true-positive:  "Nobody mentioned the gorilla in the room — the project is six months behind."
+# false-positive: "The gorilla in the enclosure at the zoo was observed using tools." (literal animal reference)
 - name: gorilla-in-the-room
   terms:
   - gorilla in the room
@@ -1045,6 +1051,8 @@ rules:
     word_boundary: false
     categories:
     - animal-violence
+# true-positive:  "Don't trust him — he's a snake in the grass waiting for a chance to betray us."
+# false-positive: "The grass snake is a harmless, non-venomous species common across Europe." (literal species description)
 - name: snake-in-the-grass
   terms:
   - snake in the grass
@@ -1058,6 +1066,8 @@ rules:
     word_boundary: false
     categories:
     - animal-violence
+# true-positive:  "The policy uses weasel words like 'may consider' to avoid any commitment."
+# false-positive: "Theodore Roosevelt introduced the term 'weasel words' in a speech criticising vague political language." (discussing the rhetorical concept — suppress with inline comment)
 - name: weasel-words
   terms:
   - weasel words
@@ -1072,6 +1082,8 @@ rules:
     word_boundary: true
     categories:
     - animal-violence
+# true-positive:  "Letting industry lobbyists write the regulations is the fox guarding the henhouse."
+# false-positive: "The farmer installed an electric fence after a fox got into the henhouse last autumn." (literal agricultural context)
 - name: fox-guarding-the-henhouse
   terms:
   - fox guarding the henhouse
@@ -1087,6 +1099,8 @@ rules:
     word_boundary: false
     categories:
     - animal-violence
+# true-positive:  "She stopped smoking cold turkey after her diagnosis."
+# false-positive: "The harm-reduction guide warns against stopping cold turkey without medical guidance." (clinical / addiction-treatment context — suppress with inline comment)
 - name: cold-turkey
   terms:
   - cold turkey
@@ -1103,6 +1117,8 @@ rules:
     word_boundary: false
     categories:
     - animal-violence
+# true-positive:  "Flaky tests late on a Friday really get my goat."
+# false-positive: "The sanctuary volunteer said the goat gets your full attention from the moment you arrive." (literal animal interaction)
 - name: get-your-goat
   terms:
   - get your goat
@@ -1120,6 +1136,8 @@ rules:
     word_boundary: false
     categories:
     - animal-violence
+# true-positive:  "We could debate this architecture decision until the cows come home."
+# false-positive: "The cows come home each evening; the farmer closes the gate at dusk." (literal farming description)
 - name: until-the-cows-come-home
   terms:
   - until the cows come home
@@ -1133,6 +1151,8 @@ rules:
     word_boundary: false
     categories:
     - animal-violence
+# true-positive:  "The vendor gave us a cock-and-bull story about why the integration failed."
+# false-positive: "The Cock and Bull is the name of the public house at the end of the high street." (proper noun)
 - name: cock-and-bull-story
   terms:
   - cock-and-bull story


### PR DESCRIPTION
## Audit findings

Full audit of all 71 existing rules across woke, alex, and vale formats. The audit checked:
- Completeness against a reference list of common LLM-generated speciesist idioms
- False positive risks from overly broad term matching
- Missing industry euphemism patterns
- Variant gaps in existing rules (pronoun-free forms, shortened forms)

---

## New rules added (15)

### Violent idioms (10)
| Phrase | Suggested alternative | Severity |
|---|---|---|
| wolf/wolves in sheep's clothing | deceptive actor | warning |
| horse trading | political bargaining | info |
| gorilla in the room | the obvious issue (elephant variant) | info |
| snake in the grass | hidden threat | warning |
| weasel words | deliberately vague language | warning |
| fox guarding the henhouse | conflicted oversight | warning |
| cold turkey | abrupt cessation | info |
| get your goat | annoy you | info |
| until the cows come home | indefinitely | info |
| cock-and-bull story | fabricated story | warning |

### Industry euphemisms (3)
| Phrase | Suggested alternative | Severity |
|---|---|---|
| harvesting animals / fish harvest | catching fish / killing animals | warning |
| free-range eggs / free-range chicken | eggs from hens with outdoor access | info |
| cage-free eggs / cage-free hens | eggs from uncaged hens / hens without cages | info |

The `free-range` and `cage-free` rules are set to `info` (not blocking) because these terms appear legitimately when quoting certification standards. The notes direct writers to describe actual conditions rather than using welfare-washing shorthand.

### Variant gap-fills (2)
- `throw to the wolves` / `thrown to the wolves` — existing rule only caught "throw **someone** to the wolves"; the pronoun-free form is equally common
- `bigger fish to fry` — standalone form; existing rule only caught "there are bigger fish to fry"

---

## False-positive refinements (3)

**`open-season`** — The previous rule matched `open season`, `opening season`, and `opened season`. The latter two match "opening season of a conference" and "opened season tickets" with no animal-violence meaning. Scoped to `open season on [X]` which only matches the idiom.

**`cull`** — Added an explicit false-positive warning to the rule note: "cull" is extremely common in data pipeline code to mean "remove duplicates" or "trim a collection". The note now directs users to inline suppression for those contexts rather than disabling the rule globally.

**`throw-to-wolves`** — Broadened the term list to include the pronoun-free forms (`throw to the wolves`, `thrown to the wolves`) which were a gap in the existing rule, not a false positive — but fixing the gap removes ambiguity about what's covered.

---

## Explicitly NOT flagging (with rationale)

| Phrase | Rationale |
|---|---|
| `raining cats and dogs` | Weather idiom; no violence or exploitation framing. Very low priority. |
| `canary deployment` | Already covered in `TechTerminology.yml` with a condition note. |
| `docker` | Container runtime name, not an animal violence idiom. |
| `python` (language) | Language name, not an animal violence idiom. |
| `hunt for bugs` / `bug hunt` | "hunt" in software contexts is firmly established technical vocabulary with no animal-harm connotation in context. Flagging would generate high false-positive volume. |
| `fish out` (retrieve) | Retrieve-from-a-collection meaning is dominant in code; extremely high false-positive risk. |
| `ferret out` | Already covered. Noted as a rare false positive if code handles actual ferret-species data. |
| `rubber duck debugging` | Already covered in `TechTerminology.yml`. |
| `pest control` as software tool name | Added as `info`-level rule with suppression guidance rather than blocking. |
| `euthanize`/`euthanasia` | Context-dependent: accurate when an animal is ill; misleading when applied to healthy animals. Too context-sensitive for a simple substitution rule without AST awareness. Deferred. |
| `squeaky pig gets the grease` | Not an established idiom — a mangled variant of "squeaky wheel". No rule needed. |

---

## Verification

- All YAML parses cleanly (validated with PyYAML)
- All 20 consistency check tests pass
- Total canonical rules: 71 → 86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added false-positive guidance for “weasel words”, “cold turkey”, and “pest control” and recommended inline suppression practices.
* **New Features**
  * Expanded detection and substitution for animal-based metaphors and idioms; added alternative, non-animal phrasings.
  * Added industry-euphemism checks for harvest/free-range/cage-free wording and welfare-washing terminology.
* **Refinements**
  * Improved phrase matching precision and added variant/scoping coverage for several existing rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->