### PR TITLE
docs: comprehensive README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,207 @@
+# AGENTS.md — no-animal-violence
+
+This repository is the **canonical rule dictionary** for the Open Paws speciesist language detection suite. It contains 65+ detection patterns across four categories (violent animal idioms, animal-as-object metaphors, speciesist tech terminology, and industry euphemisms), each with precise alternatives backed by peer-reviewed research. Eight downstream tool adapters — ESLint, Semgrep, Vale, VS Code extension, pre-commit hook, GitHub Action, reviewdog runner, and Danger.js plugin — consume or mirror these definitions. A change to a rule here propagates to all eight adapters and to any MCP servers that load the patterns at runtime.
+
+---
+
+## Status
+
+**Active Development** — the rule set is in use org-wide (decision 2026-03-25: all Open Paws repos run `semgrep --config semgrep-no-animal-violence.yaml` on every code/docs edit). No named maintainer as of 2026-04-02. Rule additions are welcomed; rule removals or ID changes are high-risk.
+
+---
+
+## Key Files
+
+| File | Description |
+|---|---|
+| `woke/.woke.yaml` | The primary canonical source. All 65+ rules in woke format. Auto-generated from `project-compassionate-code` — do not edit manually. |
+| `alex/animal-violence.yml` | Violent idioms and industry euphemisms in retext-equality/alex format. |
+| `alex/speciesism.yml` | Speciesist metaphors and tech terminology in retext-equality/alex format. Includes true/false positive examples per rule. |
+| `alex/industry-euphemisms.yml` | Harvest, free-range, and cage-free welfare-washing euphemisms in alex format. |
+| `vale/Speciesism/AnimalIdioms.yml` | Vale substitution rules: violent animal idioms. |
+| `vale/Speciesism/AnimalMetaphors.yml` | Vale substitution rules: animal-as-object metaphors. |
+| `vale/Speciesism/TechTerminology.yml` | Vale substitution rules: speciesist tech terms (canary, monkey patch, duck typing, etc.). |
+| `vale/Speciesism/IndustryEuphemisms.yml` | Vale substitution rules: agricultural euphemisms. |
+| `vale/Speciesism/meta.json` | Vale style package metadata (name, version, description). |
+| `semgrep-no-animal-violence.yaml` | Semgrep import shim — points to `semgrep-rules-no-animal-violence`. Not a rule file itself. |
+| `tools/check_consistency.py` | Validates that all three canonical formats (woke, alex, vale) cover the same patterns. Run before every PR. |
+| `scripts/check_versions.sh` | Checks installed versions of all eight downstream tools against the compatibility matrix in `VERSIONS.md`. |
+| `INTEGRATION.md` | Step-by-step setup guide for all eight downstream tools. |
+| `VERSIONS.md` | Compatibility matrix. Tracks which downstream tool version works with which core rule version. |
+
+---
+
+## Pattern Format
+
+### woke (`.woke.yaml`)
+
+Each rule is a YAML object with these fields:
+
+```yaml
+- name: rule-id-kebab-case          # unique, stable — downstream suppression comments reference this
+  terms:                            # exact phrases to flag (case-insensitive by default)
+    - the exact phrase
+    - variant phrasing
+  alternatives:                     # suggested replacements
+    - preferred phrasing
+  severity: error | warning | info  # error = blocking; warning = surfaced; info = awareness only
+  note: Human-readable explanation  # why the phrase is problematic
+  options:
+    word_boundary: true | false     # true: flag only as whole words; false: match substrings
+    categories:
+      - animal-violence | industry-euphemism
+```
+
+### alex / retext-equality (`.yml` in `alex/`)
+
+```yaml
+- type: basic
+  note: Explanation of why the phrase is problematic
+  source: https://doi.org/...       # optional academic citation
+  considerate:
+    preferred phrase: a             # 'a' is the retext-equality marker for gender-neutral
+  inconsiderate:
+    flagged phrase: category-name   # category: animal-violence | industry-euphemism | speciesism
+```
+
+The `alex/speciesism.yml` file also includes inline comment examples for true-positive and false-positive cases:
+
+```yaml
+  # true-positive:  "Sentence that should trigger this rule."
+  # false-positive: "Sentence that should NOT trigger this rule."
+```
+
+### Vale (`vale/Speciesism/*.yml`)
+
+Vale rules use the `substitution` extension:
+
+```yaml
+extends: substitution
+message: "Consider '%s' instead of '%s'."
+level: suggestion | warning | error
+ignorecase: true
+swap:
+  'flagged phrase': preferred alternative
+  'flagged variant': preferred alternative
+```
+
+---
+
+## How to Add a New Pattern Correctly
+
+Follow all steps in order. Skipping steps leaves the rule set inconsistent across tools.
+
+1. **Search before writing.** Run:
+   ```bash
+   grep -ri "your phrase" woke/ alex/ vale/
+   ```
+   If the phrase already exists, do not add a duplicate.
+
+2. **Classify the category:**
+   - `animal-violence` — direct harm idioms, animal-as-insult, animal exploitation metaphors
+   - `industry-euphemism` — agricultural/food industry language that obscures animal harm
+   - `speciesism` — normalized metaphors with precise technical alternatives
+
+3. **Write the spec first.** Define before writing YAML:
+   - Exact phrase(s) to flag
+   - Suggested alternative(s)
+   - One true-positive sentence (should trigger)
+   - One false-positive sentence (should not trigger)
+
+4. **Add to all three canonical file sets:**
+
+   a. `woke/.woke.yaml` — add a new rule object. Note: this file says "AUTO-GENERATED" at the top but is the canonical source; add rules here and propagate manually.
+
+   b. `alex/` — add to the appropriate file:
+      - Violent idioms → `alex/animal-violence.yml`
+      - Speciesist metaphors / tech terms → `alex/speciesism.yml`
+      - Agricultural euphemisms → `alex/industry-euphemisms.yml`
+
+   c. `vale/Speciesism/` — add to the appropriate file:
+      - Violent idioms → `AnimalIdioms.yml`
+      - Animal metaphors → `AnimalMetaphors.yml`
+      - Tech terminology → `TechTerminology.yml`
+      - Industry euphemisms → `IndustryEuphemisms.yml`
+
+5. **Validate consistency:**
+   ```bash
+   python tools/check_consistency.py
+   ```
+
+6. **Open issues in downstream repos** listed in `VERSIONS.md` to pull the new pattern in. Downstream tools do not auto-sync.
+
+---
+
+## Integration Points (Downstream Repos)
+
+All of these repos consume patterns from this repository:
+
+| Repo | How it consumes these rules |
+|---|---|
+| [eslint-plugin-no-animal-violence](https://github.com/Open-Paws/eslint-plugin-no-animal-violence) | Embeds patterns inline from `woke/.woke.yaml` and `alex/` |
+| [semgrep-rules-no-animal-violence](https://github.com/Open-Paws/semgrep-rules-no-animal-violence) | Mirrors patterns as Semgrep YAML rules |
+| [vale-no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) | Packages `vale/Speciesism/` as a distributable Vale style |
+| [vscode-no-animal-violence](https://github.com/Open-Paws/vscode-no-animal-violence) | Embeds patterns for real-time editor diagnostics |
+| [no-animal-violence-pre-commit](https://github.com/Open-Paws/no-animal-violence-pre-commit) | Wraps `woke` with these rules as a pre-commit hook |
+| [no-animal-violence-action](https://github.com/Open-Paws/no-animal-violence-action) | Bundles rules into a GitHub Actions CI gate |
+| [reviewdog-no-animal-violence](https://github.com/Open-Paws/reviewdog-no-animal-violence) | Posts inline PR annotations using these patterns |
+| [danger-plugin-no-animal-violence](https://github.com/Open-Paws/danger-plugin-no-animal-violence) | Posts consolidated PR review comment |
+
+**MCP ecosystem (live 2026-04-09):**
+
+| Server | How it uses these rules |
+|---|---|
+| `mcp-server-nav-language` | Loads patterns from `woke/.woke.yaml`, `alex/`, and `vale/Speciesism/` at startup. Exposes `check_language`, `check_file`, `list_rules` tools. |
+| `lbr8-mcp-constraints` | Bundles 12 offline NAV patterns as `StaticConstraintSource` for air-gapped contexts. |
+| `mcp-server-aha-evaluation` | Uses NAV rules as Stage 1 of a two-stage content evaluation pipeline. |
+
+When updating patterns here, also check whether `lbr8-mcp-constraints` (12 bundled offline patterns) needs updating.
+
+---
+
+## Safe vs. Risky Changes
+
+### Low risk (proceed normally)
+
+- Adding a new rule entry to all three canonical file sets
+- Adding new alternative suggestions to an existing rule
+- Improving a rule's `note` or `source` field
+- Adding true-positive / false-positive examples
+
+### High risk (require explicit justification and downstream coordination)
+
+- **Changing a rule ID** (`name:` field in woke, rule key in alex/vale) — downstream suppression comments reference IDs by name (e.g., `# no-animal-violence-disable-next-line kill-two-birds-with-one-stone`). Changing IDs silently breaks all existing suppressions.
+- **Removing an existing rule** — same risk as ID changes plus behavioural regression.
+- **Changing severity downward** (e.g., `error` to `info`) — may cause violations to be silently missed in CI pipelines with minimum-severity filters.
+- **Modifying the phrase list for an existing rule** — may introduce false negatives if downstream tools have cached the previous list.
+
+For any high-risk change: (1) open an issue describing the change and its justification, (2) check all eight downstream repos for inline suppression comments that reference the affected rule ID, (3) coordinate the change across repos before merging.
+
+---
+
+## Known Issues / TODOs
+
+- **No named maintainer** as of 2026-04-02. Rule additions and false-positive tuning are ideal contributions.
+- **Example-based tests are underspecified.** `tools/check_consistency.py` validates cross-file consistency but does not run the rules against example sentences. A proper test fixture (true/false positive examples per rule) would close this gap.
+- **Adoption metrics not tracked.** npm downloads, VS Code marketplace installs, and GitHub Action usage are not yet measured — a Lever 3 measurement gap.
+- **Downstream tools do not auto-sync.** New rules added here require manual issues in each downstream repo.
+- **Platform CI integration pending.** The suite has no presence in the Open Paws platform CI pipeline despite being a shipped product. See `ecosystem/integration-todos.md §27a` in the strategy repo.
+- **woke/.woke.yaml header says "AUTO-GENERATED"** — this file is the canonical source and is edited directly. The header is misleading. The auto-generation pipeline in `project-compassionate-code` generates initial rule drafts; final rules are committed here.
+
+---
+
+## Quality Gates
+
+```bash
+# Consistency check (run before every PR)
+python tools/check_consistency.py
+
+# Self-check (run the rules against this repo's own docs)
+woke --config woke/.woke.yaml .
+
+# Downstream version drift
+./scripts/check_versions.sh
+
+# Desloppify (minimum score: 85)
+desloppify scan --path .
+```

--- a/README.md
+++ b/README.md
@@ -1,53 +1,275 @@
-# No Animal Violence
+# no-animal-violence
 
-Rule files for detecting speciesist language in code, documentation, and prose. Compatible with multiple popular inclusive language scanning tools.
+**Status: 🟡 Active Development** — canonical rule source for the Open Paws speciesist language detection suite
+
+Rule files for detecting speciesist language in code, documentation, and configuration. This is the **canonical pattern dictionary** for the entire no-animal-violence ecosystem. Eight downstream tools consume or mirror these definitions.
+
+---
 
 ## What This Is
 
-Extensions for existing inclusive language tools that detect phrases normalizing violence toward animals and suggest clearer, more professional alternatives. Every major inclusive language scanner covers racial, gender, and ableist language — none currently include speciesism.
+Every major inclusive language scanner covers racial, gender, and ableist language. None include speciesism. This repository fills that gap.
 
-This project fills that gap with rule files for:
+It maintains 65+ detection patterns across four categories, each with precise, professional alternatives. The patterns are published as native rule files for three scanners (`woke`, `alex/retext-equality`, `Vale`) and are mirrored by six additional tool adapters (ESLint, Semgrep, VS Code, pre-commit, GitHub Action, reviewdog, Danger.js).
 
-- **[woke](https://github.com/get-woke/woke)** — `.woke.yaml` config file
-- **[alex / retext-equality](https://github.com/retextjs/retext-equality)** — YAML pattern file for the `data/en/` directory
-- **[Vale](https://vale.sh)** — Distributable style package
+**Changes made here propagate to all eight downstream tools.** This is the single source of truth.
 
-## What It Detects
+---
 
-### Violent Animal Idioms
-Phrases that normalize violence toward animals, with clearer professional alternatives:
-- "kill two birds with one stone" → "accomplish two things at once"
-- "beat a dead horse" → "belabor the point"
-- "more than one way to skin a cat" → "more than one way to solve this"
+## Why This Matters for Advocacy Software
 
-### Animal-as-Object Metaphors
-Terms that frame animals as tools, objects, or insults:
-- "guinea pig" → "test subject"
-- "sacred cow" → "unquestioned belief"
-- "scapegoat" → "wrongly blamed"
+Language shapes moral perception. Peer-reviewed research confirms that speciesist idioms and industry euphemisms in AI training data suppress moral concern for animals at a statistically significant level (Hagendorff et al., 2023; Takeshita et al., 2022). When those same phrases appear in developer communications, documentation, and code comments, they normalize the framing that produced the bias.
 
-### Technical Terminology
-Infrastructure metaphors with animal exploitation origins, with more precise alternatives:
-- "cattle vs. pets" → "ephemeral vs. persistent"
-- "canary deployment" → "progressive rollout"
-- "monkey patch" → "runtime patch"
+This toolchain embeds animal welfare standards into the development process itself. Every developer who installs an adapter encounters an alternative framing — and a reason for it — each time a flagged phrase appears.
 
-## Academic Foundation
-
-This work is grounded in peer-reviewed research documenting speciesist bias in language and AI systems:
-
+**Academic backing:**
 - Hagendorff, Bossert, Tse & Singer (2023). "Speciesist bias in AI." *AI and Ethics*. [DOI: 10.1007/s43681-023-00380-w](https://doi.org/10.1007/s43681-023-00380-w)
 - Takeshita, Rzepka & Araki (2022). "Speciesist language and nonhuman animal bias in English masked language models." *Information Processing & Management*.
 - Hagendorff et al. (2025). "SpeciesismBench: A benchmark for evaluating speciesist bias in large language models." arXiv:2508.11534.
 - Leach et al. (2023). "Speciesism in everyday language." *British Journal of Social Psychology*.
 
-## Adding to Your Project
+---
 
-See **[INTEGRATION.md](INTEGRATION.md)** for a single guide that covers all nine tools — from a 5-minute GitHub Action setup to the full local + CI stack in 15 minutes.
+## Pattern Categories
+
+### 1. Violent Animal Idioms (`animal-violence`) — severity: `error` or `warning`
+
+Phrases that reference harming, killing, or coercing animals:
+
+| Flagged phrase | Suggested alternative |
+|---|---|
+| kill two birds with one stone | accomplish two things at once |
+| beat a dead horse | belabor the point |
+| more than one way to skin a cat | more than one way to solve this |
+| like shooting fish in a barrel | trivially easy |
+| like lambs to the slaughter | without resistance |
+| curiosity killed the cat | curiosity led to trouble |
+| like a chicken with its head cut off | in a panic |
+| your goose is cooked | you're in trouble |
+| throw someone to the wolves | abandon to criticism |
+| bring home the bacon | bring home the results |
+| flog a dead horse | belabor the point |
+| no room to swing a cat | very cramped |
+| clip someone's wings | restrict someone's freedom |
+| open season | free-for-all |
+| sacrificial lamb | expendable person |
+| sitting duck | easy target |
+
+### 2. Animal-as-Object Metaphors (`animal-violence`) — severity: `warning` or `info`
+
+Phrases that frame animals as commodities, insults, or props:
+
+| Flagged phrase | Suggested alternative |
+|---|---|
+| guinea pig | test subject |
+| sacred cow | unquestioned belief |
+| scapegoat | blame target |
+| cash cow | profit center |
+| dead cat bounce | temporary rebound |
+| code monkey | developer |
+| cattle vs. pets | ephemeral vs. persistent |
+| herding cats | coordinating independent contributors |
+| pet project | side project |
+| rat race | daily grind |
+| dog-eat-dog | ruthlessly competitive |
+| whack-a-mole | recurring problem |
+
+### 3. Speciesist Technical Terminology (`speciesism`) — severity: `warning` or `info`
+
+Infrastructure and development metaphors with animal exploitation origins, where a more precise technical term exists:
+
+| Flagged phrase | Suggested alternative |
+|---|---|
+| canary deployment / canary release | progressive rollout |
+| monkey patch / monkey patching | runtime patch |
+| duck typing | structural typing |
+| dogfooding / eat your own dogfood | self-hosting |
+| stack canary / canary value | sentinel value |
+| rubber duck debugging | talk-through debugging |
+| wolf in sheep's clothing | deceptive actor |
+| weasel words | deliberately vague language |
+| fox guarding the henhouse | conflicted oversight |
+| horse trading | transactional negotiation |
+| cold turkey | abrupt cessation |
+
+### 4. Industry Euphemisms (`industry-euphemism`) — severity: `warning`
+
+Agricultural and food-industry language that obscures what is actually happening to animals. These terms are disproportionately represented in AI training data at ratios of 13:1 to 34:1 over accurate alternatives:
+
+| Flagged phrase | Suggested alternative | Ratio in training data |
+|---|---|---|
+| processing plant / processing facility | slaughterhouse | 34.3:1 |
+| livestock | farmed animals | 24.8:1 |
+| poultry | farmed birds | 16.5:1 |
+| gestation crate | pregnancy cage | 15.0:1 |
+| depopulation | mass killing | 13.9:1 |
+| humane slaughter | slaughter | — |
+| farrowing crate | birthing cage | — |
+| battery cage | small wire cage | — |
+| spent hen | discarded hen | — |
+| broiler | chicken raised for meat | — |
+| harvesting animals | killing animals | — |
+| free-range eggs | eggs from hens with outdoor access | — |
+| cage-free eggs | eggs from uncaged hens | — |
+
+---
+
+## Downstream Tool Ecosystem
+
+All eight adapters detect the same phrases and suggest the same alternatives. Each implements the patterns in its tool's native format. The canonical source is this repository.
+
+| Tool | Repository | What it covers |
+|---|---|---|
+| ESLint plugin | [eslint-plugin-no-animal-violence](https://github.com/Open-Paws/eslint-plugin-no-animal-violence) | JS/TS files: comments, strings, JSX |
+| Semgrep rules | [semgrep-rules-no-animal-violence](https://github.com/Open-Paws/semgrep-rules-no-animal-violence) | Multi-language static analysis with autofix |
+| Vale package | [vale-no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) | Markdown, RST, prose documentation |
+| VS Code extension | [vscode-no-animal-violence](https://github.com/Open-Paws/vscode-no-animal-violence) | Real-time editor underlining + Quick Fix |
+| Pre-commit hook | [no-animal-violence-pre-commit](https://github.com/Open-Paws/no-animal-violence-pre-commit) | Blocks commits containing violations |
+| GitHub Action | [no-animal-violence-action](https://github.com/Open-Paws/no-animal-violence-action) | CI/CD gate on every PR |
+| Reviewdog runner | [reviewdog-no-animal-violence](https://github.com/Open-Paws/reviewdog-no-animal-violence) | Inline annotations on PR diffs |
+| Danger.js plugin | [danger-plugin-no-animal-violence](https://github.com/Open-Paws/danger-plugin-no-animal-violence) | Consolidated PR review comment |
+
+For full setup instructions for all eight tools, see **[INTEGRATION.md](INTEGRATION.md)**.
+
+---
+
+## Quick Start
+
+**5-minute CI gate** — add to `.github/workflows/inclusive-language.yml`:
+
+```yaml
+name: Inclusive Language
+on: [pull_request]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Open-Paws/no-animal-violence-action@v1
+```
+
+**Pre-commit hook** — add to `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/Open-Paws/no-animal-violence-pre-commit
+    rev: v0.2.0
+    hooks:
+      - id: no-animal-violence
+```
+
+**ESLint (flat config)**:
+
+```bash
+npm install --save-dev eslint-plugin-no-animal-violence
+```
+
+```js
+// eslint.config.js
+import noAnimalViolence from "eslint-plugin-no-animal-violence";
+
+export default [
+  {
+    plugins: { "no-animal-violence": noAnimalViolence },
+    ...noAnimalViolence.configs.recommended,
+  },
+];
+```
+
+**woke** — copy or reference `woke/.woke.yaml` directly:
+
+```bash
+woke --config path/to/woke/.woke.yaml .
+```
+
+---
+
+## How to Add a New Pattern
+
+Patterns are governed by the same principles as code: clarity over cleverness, single responsibility per entry, and every new rule must include at least one true-positive example and one false-positive suppression example.
+
+### Governance process
+
+1. **Check for duplicates first.** Search `woke/.woke.yaml`, `alex/animal-violence.yml`, `alex/speciesism.yml`, `alex/industry-euphemisms.yml`, and `vale/Speciesism/` before adding anything. AI-assisted additions duplicate at a significantly higher rate than human-authored ones.
+
+2. **Classify the category.** Determine which of the four categories applies: `animal-violence` (idioms or insults), `speciesism` (normalized metaphors), `industry-euphemism` (agricultural euphemisms), or a new category if none fits.
+
+3. **Write a spec first.** Before writing the YAML, define:
+   - The exact phrase(s) to flag
+   - The suggested alternative(s)
+   - One true-positive example (a sentence that should trigger the rule)
+   - One false-positive example (a sentence that should not trigger the rule)
+
+4. **Add to all three canonical files:**
+   - `woke/.woke.yaml` — woke format
+   - `alex/` — the appropriate alex/retext-equality file
+   - `vale/Speciesism/` — the appropriate Vale rule file
+
+5. **Open issues in downstream tool repos** to pull the new pattern in. See `VERSIONS.md` for the full list of downstream repos.
+
+6. **Validate:**
+   ```bash
+   # Check cross-file consistency
+   python tools/check_consistency.py
+
+   # Run the suite against itself
+   woke --config woke/.woke.yaml .
+   ```
+
+### Severity guidelines
+
+| Severity | Use when |
+|---|---|
+| `error` | Phrase directly references animal harm with no legitimate technical use |
+| `warning` | Phrase normalizes exploitation; technical contexts may exist |
+| `info` | Common idiom; flag for awareness only; not blocking |
+
+---
+
+## Contributing
+
+1. Read the existing patterns before proposing additions — search broadly.
+2. Follow the governance process above.
+3. Run `python tools/check_consistency.py` before opening a PR.
+4. Every PR must include true-positive and false-positive examples for each new rule.
+5. PRs that modify existing rule IDs or remove patterns are high-risk and require explicit justification — downstream tool suppression comments reference rule IDs by name.
+
+---
+
+## Repository Structure
+
+```
+no-animal-violence/
+├── woke/
+│   └── .woke.yaml              # Canonical pattern dictionary (all 65+ rules)
+├── alex/
+│   ├── animal-violence.yml     # Violent idioms + industry euphemisms (alex format)
+│   ├── speciesism.yml          # Speciesist metaphors + tech terminology (alex format)
+│   └── industry-euphemisms.yml # Harvest/welfare-washing euphemisms (alex format)
+├── vale/
+│   └── Speciesism/
+│       ├── AnimalIdioms.yml    # Vale: violent animal idioms
+│       ├── AnimalMetaphors.yml # Vale: animal-as-object metaphors
+│       ├── TechTerminology.yml # Vale: speciesist tech terms
+│       ├── IndustryEuphemisms.yml # Vale: agricultural euphemisms
+│       └── meta.json           # Vale style package metadata
+├── tools/
+│   └── check_consistency.py   # Cross-file consistency validator
+├── scripts/
+│   └── check_versions.sh      # Downstream version drift detector
+├── semgrep-no-animal-violence.yaml  # Semgrep import shim
+├── INTEGRATION.md              # Full setup guide for all eight tools
+└── VERSIONS.md                 # Compatibility matrix for downstream tools
+```
+
+---
 
 ## License
 
 MIT
+
+---
 
 ## About
 


### PR DESCRIPTION
## Summary

- **README.md** — complete rewrite: status badge, why this matters for advocacy software, all four pattern categories with full tables (65+ patterns), downstream ecosystem table with links to all eight tool adapters, quick-start snippets, governance process for adding new patterns, contributing guidelines, and repo structure map.
- **AGENTS.md** — new file for AI coding agent orientation: one-paragraph summary of the repo's role in the ecosystem, status and change implications, key files with one-line descriptions, pattern format for all three canonical file formats (woke/alex/vale), exact step-by-step process for adding a new pattern, integration points for all eight downstream tool repos and three MCP servers, safe vs. risky change classification, and known issues/TODOs.

## What changed and why

The previous README covered the three pattern categories briefly but lacked: the full pattern tables, the industry-euphemism category, integration instructions for five of the eight tools, governance guidance, and the repo structure. The `AGENTS.md` is new — the `CLAUDE.md` already serves Claude Code but `AGENTS.md` is the conventional file for AI agent orientation used by other tools (e.g., OpenAI Codex, Cursor).

## Test plan

- [ ] Verify all downstream tool links resolve to valid repositories
- [ ] Confirm pattern tables match actual rule entries in `woke/.woke.yaml` and `alex/` files
- [ ] Confirm quick-start YAML snippets match those in `INTEGRATION.md`
- [ ] Confirm `AGENTS.md` safe/risky change guidance matches the 10-point review checklist in `CLAUDE.md`
