### PR TITLE
fix: restore load_canonical as public name (tests import it directly)

### DIFF
--- a/tools/check_consistency.py
+++ b/tools/check_consistency.py
@@ -104,7 +104,7 @@ class DriftReport:
         return "\n".join(lines)
 
 
-def _load_canonical(repo_dir: Path) -> list[Rule]:
+def load_canonical(repo_dir: Path) -> list[Rule]:
     """Load canonical rules from rules.yaml (preferred) or woke/.woke.yaml (fallback)."""
     rules_yaml = repo_dir / "rules.yaml"
     if _LOADER_AVAILABLE and rules_yaml.exists():
@@ -356,7 +356,7 @@ def check_vale(canonical: list, repos_dir: Path) -> list[DriftFinding]:
 
 def run_check(repo_dir: Path, repos_dir: Path) -> DriftReport:
     """Run full consistency check and return a report."""
-    canonical = _load_canonical(repo_dir)
+    canonical = load_canonical(repo_dir)
     report = DriftReport(canonical_count=len(canonical))
 
     # ESLint


### PR DESCRIPTION
## Problem

CI failing with:

```
ImportError: cannot import name 'load_canonical' from 'check_consistency'
```

A prior CodeRabbit fix prefixed the function with `_` (making it private), but `test_check_consistency.py` imports it by its public name `load_canonical` — used in 14 test call sites.

## Fix

Rename `_load_canonical` → `load_canonical` in `check_consistency.py` (definition + the single internal call site in `run_check`). No logic changed.