### PR TITLE
ci: pin no-animal-violence-action to @main

### DIFF
--- a/.github/workflows/no-animal-violence.yml
+++ b/.github/workflows/no-animal-violence.yml
@@ -5,7 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Open-Paws/no-animal-violence-action@v1
+      - uses: Open-Paws/no-animal-violence-action@main
         with:
-          fail_on_error: true
-          fail_on_warning: false
+          severity: error


### PR DESCRIPTION
## Summary

- Updates `.github/workflows/no-animal-violence.yml` to reference `Open-Paws/no-animal-violence-action@main` instead of the previous `@v1` floating tag
- Ensures this repo automatically picks up new rules when `no-animal-violence-action` merges to its own `main` branch (autosync design intent)
- Matches the canonical template in `Open-Paws/context` → `handbook/ci-templates/no-animal-violence.yml`

## Classification

**level-0** — CI config correction; no behavioral change to application code. First-party action (`@main` is equivalent to tracking the org's own release channel).

## Test plan

- [ ] Confirm no-animal-violence check passes on this PR
- [ ] Confirm workflow references `Open-Paws/no-animal-violence-action@main`