### PR TITLE
feat(rules): add lame-duck idiom rule

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -1080,3 +1080,18 @@ rules:
     word_boundary: true
     regex: "veal"
     context_suppressions: []
+
+  - name: lame-duck
+    terms:
+      - lame duck
+      - lame-duck
+    alternatives:
+      - outgoing
+      - transitional
+      - ineffective
+    severity: info
+    category: animal-violence
+    note: References a bird unable to fly due to injury. 'Outgoing' or 'transitional' are more precise in political and tech contexts.
+    word_boundary: true
+    regex: "lame[\\s-]duck"
+    context_suppressions: []


### PR DESCRIPTION
Adds `lame-duck` to `rules.yaml` as a proof-of-concept end-to-end test of the push-model pipeline.

**Rule:** `lame duck` / `lame-duck` → `outgoing`, `transitional`, `ineffective`  
**Category:** `animal-violence`  
**Severity:** `info`  
**Rationale:** References a bird unable to fly due to injury. Commonly used in political and tech contexts where more precise alternatives exist.

Once this merges to `main`, the `propagate.yml` workflow should auto-fire (triggered by the `rules.yaml` path filter) and open sync PRs in all 10 downstream repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new rule that detects the phrases `lame duck` and `lame-duck` in content. The rule offers alternative word suggestions including `outgoing`, `transitional`, and `ineffective` for consideration. Operating at an informational level, this rule provides feedback during content review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->