### PR TITLE
fix(propagate): correct semgrep-rules branch from master to main

### DIFF
--- a/tools/propagate.py
+++ b/tools/propagate.py
@@ -29,7 +29,7 @@ DOWNSTREAM_REPOS = [
     },
     {
         "repo": "Open-Paws/semgrep-rules-no-animal-violence",
-        "branch": "master",
+        "branch": "main",
         "files": {
             "rules/animal-violence-generic.yaml": f"{SEMGREP_BUILD}animal-violence-generic.yaml",
             "rules/animal-violence-python.yaml": f"{SEMGREP_BUILD}animal-violence-python.yaml",


### PR DESCRIPTION
**Root cause:** `DOWNSTREAM_REPOS` in `tools/propagate.py` had `\"branch\": \"master\"` hardcoded for `semgrep-rules-no-animal-violence`. The repo's actual default branch is `main`. This caused every propagate run to fail on that repo with `fatal: Remote branch master not found in upstream origin`.\n\n**Fix:** Change `\"branch\": \"master\"` → `\"branch\": \"main\"` for that entry. One character change.