### PR TITLE
fix: correct word-boundary escaping in gen_vscode.js and add reviewdog output reformatter

### DIFF
--- a/tools/generators/gen_reviewdog.py
+++ b/tools/generators/gen_reviewdog.py
@@ -8,7 +8,9 @@ This generator writes the file deterministically.
 """
 from __future__ import annotations
 
+import re
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -66,12 +68,51 @@ runs:
           -not -path "./node_modules/*" \\
           -not -path "./vendor/*" \\
           -exec no-animal-violence-check {} + 2>&1 \\
+          | python3 -c "
+        import sys, re
+        file_re = re.compile(r'^\\s{2}(\\S.*):(\\d+)$')
+        found_re = re.compile(r'^\\s{4}Found:\\s+\\\"(.+)\\\"$')
+        cur_loc = None
+        for line in sys.stdin:
+            line = line.rstrip()
+            m = file_re.match(line)
+            if m:
+                cur_loc = (m.group(1), m.group(2))
+                continue
+            m = found_re.match(line)
+            if m and cur_loc:
+                print(f'{cur_loc[0]}:{cur_loc[1]}: {m.group(1)}')
+                cur_loc = None
+        " \\
           | reviewdog -efm="%f:%l: %m" \\
               -name="no-animal-violence" \\
               -reporter=${{ inputs.reporter }} \\
               -level=${{ inputs.level }} \\
               -filter-mode=${{ inputs.filter_mode }}
 """
+
+
+def reformat_nav_output(lines: Iterable[str]) -> list[str]:
+    """Convert multi-line no-animal-violence-check output to file:line: message lines.
+
+    The pre-commit checker outputs multi-line blocks; reviewdog's -efm="%f:%l: %m"
+    expects single-line entries. This function performs that conversion.
+    """
+    file_re = re.compile(r"^\s{2}(\S.*):(\d+)$")
+    found_re = re.compile(r'^\s{4}Found:\s+"(.+)"$')
+    out: list[str] = []
+    cur_loc: tuple[str, str] | None = None
+    for line in lines:
+        line = line.rstrip()
+        m = file_re.match(line)
+        if m:
+            cur_loc = (m.group(1), m.group(2))
+            continue
+        m = found_re.match(line)
+        if m and cur_loc:
+            out.append(f"{cur_loc[0]}:{cur_loc[1]}: {m.group(1)}")
+            cur_loc = None
+    return out
 
 
 def main() -> int:

--- a/tools/generators/gen_vscode.js
+++ b/tools/generators/gen_vscode.js
@@ -19,6 +19,9 @@ const OUTPUT_PATH = path.join(
 function loadRules() {
 	const content = fs.readFileSync(RULES_YAML, "utf8");
 	const data = yaml.load(content);
+	if (!data || !Array.isArray(data.rules)) {
+		throw new Error(`Invalid rules file: expected root object with a "rules" array (${RULES_YAML})`);
+	}
 	return data.rules;
 }
 
@@ -29,11 +32,12 @@ function escapeStringLiteral(s) {
 function buildPatternEntries(rules) {
 	return rules.map((r) => {
 		const regex = r.regex;
-		const wb = r.word_boundary;
-		const pattern = wb ? `\\\\b${regex}\\\\b` : regex;
+		const wb = r.word_boundary !== false;
+		const pattern = wb ? `\\b${regex}\\b` : regex;
+		const patternForLiteral = pattern.replace(/\//g, "\\/");
 		const phrase = escapeStringLiteral(r.terms[0]);
 		const suggest = escapeStringLiteral(r.alternatives[0]);
-		return `\t\t{\n\t\t\tpattern: /${pattern}/gi,\n\t\t\tphrase: "${phrase}",\n\t\t\tsuggest: "${suggest}",\n\t\t},`;
+		return `\t\t{\n\t\t\tpattern: /${patternForLiteral}/gi,\n\t\t\tphrase: "${phrase}",\n\t\t\tsuggest: "${suggest}",\n\t\t},`;
 	}).join("\n");
 }
 

--- a/tools/generators/tests/test_generators.py
+++ b/tools/generators/tests/test_generators.py
@@ -1,4 +1,6 @@
 """Golden-file tests for all generators."""
+import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -106,3 +108,50 @@ def test_vale_all_terms_present(tmp_path):
     assert "guinea pig" in data["swap"]
     assert "livestock" in data["swap"]
     assert "curiosity killed the cat" in data["swap"]
+
+
+def test_vscode_word_boundary_emission():
+    """gen_vscode emits /\\b.../gi for word_boundary:true rules, not /\\\\b.../gi.
+
+    Regression test for the double-escape bug: \\\\b in a JS template literal
+    produces \\b in the string, which in a regex literal means literal backslash+b
+    not a word boundary. The fix uses \\b → \\b in the output.
+    """
+    result = subprocess.run(
+        ["node", str(GENERATORS / "gen_vscode.js")],
+        capture_output=True, text=True, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    output = (REPO_ROOT / "build" / "vscode-no-animal-violence" / "extension.js").read_text()
+    # Double-escaped \\b must not appear — that was the broken form
+    assert "/\\\\b" not in output, "Double-escaped \\\\b found — word boundary fix regressed"
+    # At least one word_boundary:true rule must emit correct /\b...\b/gi form
+    assert re.search(r"/\\b[^/]+\\b/gi", output), "No /\\b...\\b/gi pattern found — word boundaries missing"
+
+
+def test_reviewdog_output_reformatter():
+    """reformat_nav_output converts multi-line scanner output to file:line: message.
+
+    Regression test for the reviewdog -efm format mismatch: the pre-commit checker
+    outputs multi-line blocks but reviewdog -efm="%f:%l: %m" expects single-line
+    entries. The reformatter must extract file, line, and found phrase.
+    """
+    from gen_reviewdog import reformat_nav_output
+    sample = [
+        "Animal violence language detected:\n",
+        "\n",
+        "  path/to/file.py:5\n",
+        '    Found:   "guinea pig"\n',
+        '    Suggest: "test subject"\n',
+        "\n",
+        "  another/file.md:12\n",
+        '    Found:   "livestock"\n',
+        '    Suggest: "farmed animals"\n',
+        "\n",
+        "2 instance(s) found.\n",
+    ]
+    result = reformat_nav_output(sample)
+    assert result == [
+        "path/to/file.py:5: guinea pig",
+        "another/file.md:12: livestock",
+    ]


### PR DESCRIPTION
Replaces #42 (same content, clean merge base against main).

## Bug 1 — `gen_vscode.js`: double-escaped word boundaries broke 39/73 rules

**Old code:**
```js
const pattern = wb ? `\\\\b${regex}\\\\b` : regex;
```
`\\\\b` in a template literal → `\\b` string → `/\\b.../gi` in output → **literal backslash+b**, not a word boundary. All 39 `word_boundary: true` rules silently matched anywhere in a word. Affected: `guinea-pig`, `livestock`, `master-slave`, `whitelist-blacklist`, `red-herring`, and 30 others.

**Fix:** `\\b` → `/\b.../gi` in output → correct word boundary.

## Bug 2 — `gen_reviewdog.py`: format mismatch, reviewdog posted zero comments

`reviewdog -efm="%f:%l: %m"` expects `path:line: message` but the checker outputs multi-line blocks. Result: zero inline PR comments on every run.

**Fix:** inline Python reformatter between checker and reviewdog converts multi-line to single-line format. Tested manually.

## CodeRabbit feedback also applied
- `wb !== false` default so rules omitting `word_boundary` get boundaries
- `loadRules` YAML guard (fast-fail on malformed `rules.yaml`)
- Forward-slash escaping in regex literals (defensive)
- Extracted `reformat_nav_output` as importable/testable function
- Two regression tests locking in both fixes (10/10 passing)