### PR TITLE
fix: apply word_boundary flag across all generators (pre-commit, semgrep, eslint, danger)

### DIFF
--- a/tools/generators/gen_danger.js
+++ b/tools/generators/gen_danger.js
@@ -25,8 +25,10 @@ function loadRules() {
 
 function buildPatternEntries(rules) {
 	return rules.map((r) => {
+		const wb = r.word_boundary !== false;
+		const raw = wb ? `\\b${r.regex}\\b` : r.regex;
 		const altsJson = JSON.stringify(r.alternatives);
-		return `  { regex: new RegExp(${JSON.stringify(r.regex)}, "gi"), phrase: ${JSON.stringify(r.terms[0])}, alternatives: ${altsJson} },`;
+		return `  { regex: new RegExp(${JSON.stringify(raw)}, "gi"), phrase: ${JSON.stringify(r.terms[0])}, alternatives: ${altsJson} },`;
 	}).join("\n");
 }
 

--- a/tools/generators/gen_eslint.js
+++ b/tools/generators/gen_eslint.js
@@ -25,37 +25,26 @@ function loadRules() {
 	return data.rules;
 }
 
-function buildMapEntries(rules) {
-	return rules
-		.map((r) => {
-			const term = r.terms[0];
-			const alt = r.alternatives[0];
-			return `\t[${JSON.stringify(term)}, ${JSON.stringify(alt)}],`;
-		})
-		.join("\n");
+function buildPatternEntries(rules) {
+	return rules.map((r) => {
+		const wb = r.word_boundary !== false;
+		const raw = wb ? `\\b${r.regex}\\b` : r.regex;
+		const patternForLiteral = raw.replace(/\//g, "\\/");
+		const phrase = r.terms[0].replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+		const alt = r.alternatives[0].replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+		return `\t{ pattern: /${patternForLiteral}/gi, phrase: "${phrase}", alt: "${alt}" },`;
+	}).join("\n");
 }
 
 // Static boilerplate lines for the generated ESLint rule file.
 // Stored as an array to avoid complex escaping in template literals.
 const STATIC_BOILERPLATE_LINES = [
 	"",
-	"function buildPattern() {",
-	"\tconst escaped = Array.from(VIOLENT_ANIMAL_PHRASES.keys()).map((phrase) =>",
-	'\t\tphrase.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&"),',
-	"\t);",
-	"\tescaped.sort((a, b) => b.length - a.length);",
-	'\treturn new RegExp(`\\\\b(?:${escaped.join("|")})\\\\b`, "gi");',
-	"}",
-	"",
-	"const PATTERN = buildPattern();",
-	"",
 	"function checkText(context, node, text, offsetCalculator) {",
-	"\tPATTERN.lastIndex = 0;",
-	"\tlet match = PATTERN.exec(text);",
-	"\twhile (match !== null) {",
-	"\t\tconst phrase = match[0].toLowerCase();",
-	"\t\tconst alternative = VIOLENT_ANIMAL_PHRASES.get(phrase);",
-	"\t\tif (alternative) {",
+	"\tfor (const { pattern, phrase, alt } of PATTERNS) {",
+	"\t\tpattern.lastIndex = 0;",
+	"\t\tlet match;",
+	"\t\twhile ((match = pattern.exec(text)) !== null) {",
 	"\t\t\tconst loc = offsetCalculator ? offsetCalculator(match.index) : node.loc.start;",
 	"\t\t\tcontext.report({",
 	"\t\t\t\tnode,",
@@ -63,11 +52,10 @@ const STATIC_BOILERPLATE_LINES = [
 	'\t\t\t\tmessageId: "avoidViolentAnimalLanguage",',
 	"\t\t\t\tdata: {",
 	"\t\t\t\t\tphrase: match[0],",
-	"\t\t\t\t\talternatives: alternative,",
+	"\t\t\t\t\talternatives: alt,",
 	"\t\t\t\t},",
 	"\t\t\t});",
 	"\t\t}",
-	"\t\tmatch = PATTERN.exec(text);",
 	"\t}",
 	"}",
 	"",
@@ -121,15 +109,15 @@ const STATIC_BOILERPLATE_LINES = [
 
 function main() {
 	const rules = loadRules();
-	const mapEntries = buildMapEntries(rules);
+	const patternEntries = buildPatternEntries(rules);
 
 	const output = [
 		"// AUTO-GENERATED from Open-Paws/no-animal-violence. Do not edit directly.",
 		'"use strict";',
 		"",
-		"const VIOLENT_ANIMAL_PHRASES = new Map([",
-		mapEntries,
-		"]);",
+		"const PATTERNS = [",
+		patternEntries,
+		"];",
 		...STATIC_BOILERPLATE_LINES,
 	].join("\n");
 

--- a/tools/generators/gen_pre_commit.py
+++ b/tools/generators/gen_pre_commit.py
@@ -73,8 +73,11 @@ def generate(rules: list[Rule], output_path: Path) -> None:
     pattern_lines = []
     for rule in rules:
         escaped_regex = rule.regex.replace('"', '\\"')
+        if rule.word_boundary:
+            escaped_regex = f'\\b(?:{escaped_regex})\\b'
         escaped_alt = rule.primary_alt.replace('"', '\\"')
         pattern_lines.append(f'    (r"{escaped_regex}", "{escaped_alt}"),')
+
 
     patterns_block = "\n".join(pattern_lines)
 

--- a/tools/generators/gen_semgrep.py
+++ b/tools/generators/gen_semgrep.py
@@ -49,8 +49,9 @@ def generate_generic(rules: list[Rule], output_path: Path) -> None:
         alts = _alts_str(rule)
         autofix = _autofix_note(rule)
         msg = f'Animal violence language: "{rule.primary_term}". Consider: {alts}{autofix}'
+        pattern = f'\\b(?:{rule.regex})\\b' if rule.word_boundary else rule.regex
         lines.append(f"- id: animal-violence.{rule.name}\n")
-        lines.append(f"  pattern-regex: '{_safe_yaml_single_quoted(rule.regex)}'\n")
+        lines.append(f"  pattern-regex: '{_safe_yaml_single_quoted(pattern)}'\n")
         lines.append(f"  message: '{_safe_yaml_single_quoted(msg)}'\n")
         lines.append("  languages:\n")
         lines.append("  - generic\n")
@@ -86,12 +87,13 @@ def _generate_lang_file(
             f'Animal violence language in string: "{rule.primary_term}". '
             f"Consider: {alts}{autofix}"
         )
+        bounded = f'\\b(?:{rule.regex})\\b' if rule.word_boundary else rule.regex
         lines.append(f"- id: {rule_id_prefix}.{rule.name}\n")
         lines.append("  patterns:\n")
         lines.append("  - pattern: $S\n")
         lines.append("  - metavariable-regex:\n")
         lines.append("      metavariable: $S\n")
-        lines.append(f"      regex: '.*{_safe_yaml_single_quoted(rule.regex)}.*'\n")
+        lines.append(f"      regex: '.*{_safe_yaml_single_quoted(bounded)}.*'\n")
         lines.append(f"  message: '{_safe_yaml_single_quoted(msg)}'\n")
         lines.append("  languages:\n")
         lines.append(lang_yaml + "\n")
@@ -102,7 +104,7 @@ def _generate_lang_file(
         lines.append(f"    alternative: '{_safe_yaml_single_quoted(rule.primary_alt)}'\n")
         if rule.severity in ("error", "warning"):
             lines.append("  fix-regex:\n")
-            lines.append(f"    regex: '{_safe_yaml_single_quoted(rule.regex)}'\n")
+            lines.append(f"    regex: '{_safe_yaml_single_quoted(bounded)}'\n")
             lines.append(f"    replacement: '{_safe_yaml_single_quoted(rule.primary_alt)}'\n")
     output_path.write_text("".join(lines), encoding="utf-8")
 

--- a/tools/generators/tests/test_generators.py
+++ b/tools/generators/tests/test_generators.py
@@ -155,3 +155,66 @@ def test_reviewdog_output_reformatter():
         "path/to/file.py:5: guinea pig",
         "another/file.md:12: livestock",
     ]
+
+
+def test_pre_commit_word_boundary(tmp_path):
+    """gen_pre_commit wraps word_boundary:true patterns with \\b and leaves false ones bare."""
+    from gen_pre_commit import generate
+    rules = load_rules(FIXTURES / "rules_mini.yaml")
+    output_path = tmp_path / "no_animal_violence_check.py"
+    generate(rules, output_path)
+    content = output_path.read_text()
+    # guinea-pig has word_boundary:true — must have \b boundaries
+    assert r'(r"\b(?:guinea\s+pig)\b"' in content
+    # curiosity-killed-the-cat has word_boundary:false — must NOT have \b
+    assert r'(r"curiosity\s+killed\s+the\s+cat"' in content
+    assert r'\b(?:curiosity' not in content
+
+
+def test_semgrep_generic_word_boundary(tmp_path):
+    """gen_semgrep wraps word_boundary:true pattern-regex with \\b and leaves false ones bare."""
+    from gen_semgrep import generate_generic
+    rules = load_rules(FIXTURES / "rules_mini.yaml")
+    output_path = tmp_path / "animal-violence-generic.yaml"
+    generate_generic(rules, output_path)
+    content = output_path.read_text()
+    # guinea-pig: word_boundary:true
+    assert r"pattern-regex: '\b(?:guinea\s+pig)\b'" in content
+    # curiosity: word_boundary:false — raw regex, no \b
+    assert "pattern-regex: 'curiosity\\s+killed\\s+the\\s+cat'" in content
+    assert r"\b(?:curiosity" not in content
+
+
+def test_eslint_word_boundary(tmp_path):
+    """gen_eslint emits per-rule patterns respecting word_boundary, using r.regex not r.terms[0]."""
+    result = subprocess.run(
+        ["node", str(GENERATORS / "gen_eslint.js")],
+        capture_output=True, text=True, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    output = (
+        REPO_ROOT / "build" / "eslint-plugin-no-animal-violence"
+        / "lib" / "rules" / "no-violent-language.js"
+    ).read_text()
+    # word_boundary:true — must use \b and the canonical regex (not the literal term)
+    assert re.search(r"/\\bguinea\\s\+pig\\b/gi", output), "guinea-pig missing word boundaries or wrong pattern"
+    # word_boundary:false — no \b
+    assert re.search(r"/curiosity\\s\+killed\\s\+the\\s\+cat/gi", output)
+    assert "\\bcuriosity" not in output
+
+
+def test_danger_word_boundary(tmp_path):
+    """gen_danger wraps word_boundary:true regexes with \\b and leaves false ones bare."""
+    result = subprocess.run(
+        ["node", str(GENERATORS / "gen_danger.js")],
+        capture_output=True, text=True, cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    output = (
+        REPO_ROOT / "build" / "danger-plugin-no-animal-violence" / "src" / "index.ts"
+    ).read_text()
+    # word_boundary:true
+    assert r'"\\bguinea\\s+pig\\b"' in output
+    # word_boundary:false — no \b prefix
+    assert r'"curiosity\\s+killed\\s+the\\s+cat"' in output
+    assert r'"\\bcuriosity' not in output


### PR DESCRIPTION
The `word_boundary` field in `rules.yaml` was only respected by `gen_vscode.js` (fixed in #43). All four remaining generators silently ignored it, causing cross-tool inconsistency: the same rule flagged different text depending on which tool the developer used.

## Bugs fixed

**`gen_pre_commit.py`** — never applied `\b` boundaries, regardless of the flag. `"livestock"` matched `"livestockfarm"`; `"abort"` matched `"aborted"`. Fix: wrap with `\b(?:...)\b` when `rule.word_boundary` is True.

**`gen_semgrep.py`** — same problem at three emission sites: `pattern-regex` in `generate_generic`, and `metavariable-regex` + `fix-regex` in `_generate_lang_file`. All three fixed.

**`gen_danger.js`** — ignored `r.word_boundary` entirely in `buildPatternEntries`. Fix: wrap with `\b...\b` when `r.word_boundary !== false`.

**`gen_eslint.js`** — two distinct bugs:
1. Used `r.terms[0]` (human-readable phrase) as the match source, not `r.regex`. `"guinea pig"` matched literal `"guinea pig"` but missed variants handled by `guinea\s+pig`.
2. Always applied `\b` to everything via `buildPattern()`, ignoring `word_boundary:false` rules.

Rebuilt to emit a per-rule `PATTERNS` array (same approach as VS Code and Danger) so each rule's regex and `word_boundary` flag are both respected.

## Consistent behaviour after this fix

| Tool | word_boundary:true | word_boundary:false |
|---|---|---|
| VS Code | ✅ #43 | ✅ #43 |
| pre-commit | ✅ this PR | ✅ this PR |
| Semgrep | ✅ this PR | ✅ this PR |
| ESLint | ✅ this PR | ✅ this PR |
| Danger | ✅ this PR | ✅ this PR |
| reviewdog | ✅ (wraps pre-commit) | ✅ |

## Tests

Four new regression tests (one per generator), covering both `word_boundary:true` and `word_boundary:false` cases using the `rules_mini.yaml` fixture. **14/14 tests pass.**