### PR TITLE
chore(regen): sync canonical format files from rules.yaml

### DIFF
--- a/alex/animal-violence.yml
+++ b/alex/animal-violence.yml
@@ -1,5 +1,4 @@
-# AUTO-GENERATED from project-compassionate-code. Do not edit directly.
-# Animal violence language patterns for retext-equality / alex
+# AUTO-GENERATED from Open-Paws/no-animal-violence. Do not edit directly.
 # Source: https://doi.org/10.1007/s43681-023-00380-w
 
 - type: basic
@@ -10,6 +9,8 @@
     hit two targets with one shot: a
   inconsiderate:
     kill two birds with one stone: animal-violence
+    killing two birds with one stone: animal-violence
+    killed two birds with one stone: animal-violence
   source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Violent animal idiom — alternatives are more direct
@@ -29,6 +30,8 @@
     several ways to accomplish this: a
   inconsiderate:
     more than one way to skin a cat: animal-violence
+    many ways to skin a cat: animal-violence
+    other ways to skin a cat: animal-violence
   source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal idiom — alternatives are more precise
@@ -38,6 +41,8 @@
     let it slip: a
   inconsiderate:
     let the cat out of the bag: animal-violence
+    letting the cat out of the bag: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal idiom — alternatives communicate the idea more directly
   considerate:
@@ -46,6 +51,9 @@
     open Pandora's box: a
   inconsiderate:
     open a can of worms: animal-violence
+    opening a can of worms: animal-violence
+    opened a can of worms: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal idiom — alternatives are more universally understood
   considerate:
@@ -54,6 +62,7 @@
     fool's errand: a
   inconsiderate:
     wild goose chase: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Violent animal idiom with shorter alternatives
   considerate:
@@ -81,14 +90,17 @@
     bigger issues at hand: a
   inconsiderate:
     there are bigger fish to fry: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
-  note: Animal-as-experiment metaphor — alternatives are more precise in technical contexts
+  note: Animal-as-experiment metaphor — alternatives are more precise in technical
+    contexts
   considerate:
     test subject: a
     first to try: a
     early adopter: a
   inconsiderate:
     guinea pig: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal idiom — alternatives are more direct
   considerate:
@@ -97,6 +109,7 @@
     be patient: a
   inconsiderate:
     hold your horses: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Well-understood idiom — flag for awareness only
   considerate:
@@ -104,6 +117,7 @@
     the unaddressed problem: a
   inconsiderate:
     the elephant in the room: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal idiom — alternatives are clearer for international audiences
   considerate:
@@ -112,6 +126,7 @@
     from the authority: a
   inconsiderate:
     straight from the horse's mouth: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal slaughter idiom — alternatives are equally expressive
   considerate:
@@ -120,6 +135,9 @@
     win the prize: a
   inconsiderate:
     bring home the bacon: animal-violence
+    bringing home the bacon: animal-violence
+    brought home the bacon: animal-violence
+    brings home the bacon: animal-violence
   source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Bullfighting idiom — alternatives convey the same assertiveness
@@ -129,6 +147,9 @@
     seize the opportunity: a
   inconsiderate:
     take the bull by the horns: animal-violence
+    taking the bull by the horns: animal-violence
+    took the bull by the horns: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Violent animal idiom referencing slaughter — alternatives are more descriptive
   considerate:
@@ -146,6 +167,7 @@
     barely any room: a
   inconsiderate:
     no room to swing a cat: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal-origin idiom — flag for awareness only
   considerate:
@@ -154,6 +176,7 @@
     misleading clue: a
   inconsiderate:
     red herring: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Directly references killing a cat
   considerate:
@@ -189,6 +212,8 @@
     sacrifice someone: a
   inconsiderate:
     throw someone to the wolves: animal-violence
+    throwing someone to the wolves: animal-violence
+    threw someone to the wolves: animal-violence
   source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References hooking fish — fishing kills fish
@@ -198,6 +223,7 @@
     fell for it entirely: a
   inconsiderate:
     hook, line, and sinker: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References wing-clipping — physical mutilation done to farmed birds
   considerate:
@@ -206,6 +232,9 @@
     hold someone back: a
   inconsiderate:
     clip someone's wings: animal-violence
+    clipping someone's wings: animal-violence
+    clipped someone's wings: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References overloading a pack animal until injury
   considerate:
@@ -214,6 +243,7 @@
     the final provocation: a
   inconsiderate:
     the straw that broke the camel's back: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References trapping and catching wild birds
   considerate:
@@ -221,6 +251,7 @@
     certainty over speculation: a
   inconsiderate:
     a bird in the hand is worth two in the bush: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References eating a killed bird as punishment
   considerate:
@@ -229,6 +260,8 @@
     accept humiliation: a
   inconsiderate:
     eat crow: animal-violence
+    eating crow: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References animal fighting
   considerate:
@@ -237,6 +270,9 @@
     have constant conflict: a
   inconsiderate:
     fight like cats and dogs: animal-violence
+    fighting like cats and dogs: animal-violence
+    fought like cats and dogs: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References baiting hooks to catch and kill fish
   considerate:
@@ -245,6 +281,9 @@
     be deceived: a
   inconsiderate:
     take the bait: animal-violence
+    taking the bait: animal-violence
+    took the bait: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References farming chickens as commodity and property
   considerate:
@@ -253,118 +292,7 @@
     don't get ahead of yourself: a
   inconsiderate:
     don't count your chickens before they hatch: animal-violence
-- type: basic
-  note: Industry commodity framing (24.8:1 ratio vs 'farmed animals' in training data). Defines sentient beings by their commercial
-    function. 'Farmed animals' is factually equivalent and does not erase the subject.
-  considerate:
-    farmed animals: a
-    animals raised for food: a
-  inconsiderate:
-    livestock: industry-euphemism
-- type: basic
-  note: Industry commodity framing (16.5:1 ratio vs 'farmed birds' in training data). Abstracts individual birds into a bulk
-    commodity term. 'Farmed birds' or the specific species name is more precise.
-  considerate:
-    farmed birds: a
-    chickens: a
-    chickens and turkeys: a
-  inconsiderate:
-    poultry: industry-euphemism
-- type: basic
-  note: Industry euphemism (15.0:1 ratio vs 'pregnancy cage' in training data). A metal enclosure so small a pregnant sow
-    cannot turn around for her entire 3.5-month pregnancy. 'Pregnancy cage' describes what it actually is.
-  considerate:
-    pregnancy cage: a
-    pregnancy cages: a
-  inconsiderate:
-    gestation crate: industry-euphemism
-    gestation crates: industry-euphemism
   source: https://doi.org/10.1007/s43681-023-00380-w
-- type: basic
-  note: Industry euphemism (13.9:1 ratio vs 'mass killing' in training data). Used to describe killing entire flocks or herds,
-    typically via gassing, ventilation shutdown, or foam. Suppress in database or population statistics contexts where 'depopulation'
-    means removing data rows.
-  considerate:
-    mass killing: a
-    killed en masse: a
-    killing en masse: a
-  inconsiderate:
-    depopulation: industry-euphemism
-    depopulated: industry-euphemism
-    depopulating: industry-euphemism
-- type: basic
-  note: Industry euphemism (34.3:1 ratio vs 'slaughterhouse' in training data). When referring to facilities that kill animals,
-    'slaughterhouse' is the accurate term.
-  considerate:
-    slaughterhouse: a
-    slaughterhouses: a
-  inconsiderate:
-    processing plant: industry-euphemism
-    processing plants: industry-euphemism
-    processing facility: industry-euphemism
-    processing facilities: industry-euphemism
-- type: basic
-  note: Industry euphemism. A metal cage that confines a sow during and after birth, preventing her from turning around or
-    reaching her piglets. 'Birthing cage' describes the reality.
-  considerate:
-    birthing cage: a
-    birthing cages: a
-  inconsiderate:
-    farrowing crate: industry-euphemism
-    farrowing crates: industry-euphemism
-  source: https://doi.org/10.1007/s43681-023-00380-w
-- type: basic
-  note: Industry euphemism. Wire enclosures giving each hen less floor space than a sheet of paper (67 sq inches / 432 sq
-    cm). The word 'battery' obscures that this is a tiny cage stacked in rows of thousands.
-  considerate:
-    small wire cage: a
-    small wire cages: a
-    confined cage: a
-    confined cages: a
-  inconsiderate:
-    battery cage: industry-euphemism
-    battery cages: industry-euphemism
-  source: https://doi.org/10.1007/s43681-023-00380-w
-- type: basic
-  note: 'Industry euphemism. ''Spent'' frames a living hen as a depleted resource. These hens are typically killed at 18 months
-    (natural lifespan: 8-10 years) when egg production drops below commercial thresholds.'
-  considerate:
-    discarded hen: a
-    discarded hens: a
-    hen killed after egg production declines: a
-  inconsiderate:
-    spent hen: industry-euphemism
-    spent hens: industry-euphemism
-  source: https://doi.org/10.1007/s43681-023-00380-w
-- type: basic
-  note: Industry oxymoron. The adjective 'humane' sanitizes the act. USDA 'humane slaughter' standards permit bolt guns, electrocution,
-    and gas chambers. The alternative drops the misleading modifier — the act is slaughter regardless of method.
-  considerate:
-    slaughter: a
-    slaughtered: a
-    killing: a
-    killed: a
-  inconsiderate:
-    humane slaughter: industry-euphemism
-    humanely slaughter: industry-euphemism
-    humane slaughtered: industry-euphemism
-    humanely slaughtered: industry-euphemism
-    humane killing: industry-euphemism
-    humanely killing: industry-euphemism
-    humane killed: industry-euphemism
-    humanely killed: industry-euphemism
-  source: https://doi.org/10.1007/s43681-023-00380-w
-- type: basic
-  note: Industry commodity term that defines a living chicken entirely by its commercial purpose. When referring to animals,
-    'chicken raised for meat' is accurate without reducing the animal to a product category.
-  considerate:
-    chicken raised for meat: a
-    chickens raised for meat: a
-    meat chicken: a
-    meat chickens: a
-  inconsiderate:
-    broiler: industry-euphemism
-    broilers: industry-euphemism
 - type: basic
   note: Animal-as-coward insult in comments
   considerate:
@@ -373,6 +301,7 @@
     go for it: a
   inconsiderate:
     don't be a chicken: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal-as-insult for resource consumption
   considerate:
@@ -381,6 +310,7 @@
     heavy consumer: a
   inconsiderate:
     pig: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Not directly animal-related but reinforces animal industry terminology
   considerate:
@@ -389,6 +319,7 @@
     code without process: a
   inconsiderate:
     cowboy coding: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal-as-insult for programmers — dehumanizing and unprofessional
   considerate:
@@ -397,6 +328,7 @@
     engineer: a
   inconsiderate:
     code monkey: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: From badger-baiting — a blood sport where dogs attack captive badgers
   considerate:
@@ -405,6 +337,7 @@
     harass: a
   inconsiderate:
     badger someone: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: From using ferrets to hunt rabbits out of burrows
   considerate:
@@ -413,6 +346,7 @@
     dig up: a
   inconsiderate:
     ferret out: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Infrastructure metaphor — alternatives are technically more precise
   considerate:
@@ -429,6 +363,7 @@
     passion project: a
   inconsiderate:
     pet project: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal metaphor — alternatives are more technical
   considerate:
@@ -437,6 +372,7 @@
     sentinel: a
   inconsiderate:
     canary in a coal mine: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Common tech term — flag for awareness only
   considerate:
@@ -445,6 +381,10 @@
     using internally: a
   inconsiderate:
     dogfooding: animal-violence
+    dogfood: animal-violence
+    eating your own dogfood: animal-violence
+    eat your own dogfood: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal metaphor — alternatives are more descriptive
   considerate:
@@ -453,6 +393,7 @@
     organizing chaos: a
   inconsiderate:
     herding cats: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Animal metaphor — alternatives are more precise
   considerate:
@@ -461,8 +402,10 @@
     speculative inquiry: a
   inconsiderate:
     go on a fishing expedition: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
-  note: Animal objectification with cultural insensitivity — trivializes Hindu beliefs while treating cattle as objects
+  note: Animal objectification with cultural insensitivity — trivializes Hindu beliefs
+    while treating cattle as objects
   considerate:
     unquestioned belief: a
     untouchable topic: a
@@ -481,6 +424,7 @@
     scapegoat: animal-violence
     scapegoated: animal-violence
     scapegoating: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Derogatory animal metaphor for futility — alternatives are more descriptive
   considerate:
@@ -489,6 +433,7 @@
     endless hustle: a
   inconsiderate:
     rat race: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Financial/tech term depicting animal death — alternatives are more professional
   considerate:
@@ -506,14 +451,19 @@
     fiercely competitive: a
   inconsiderate:
     dog-eat-dog: animal-violence
+    dog eat dog: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
-  note: References a game based on hitting animals — alternatives describe the pattern more precisely
+  note: References a game based on hitting animals — alternatives describe the pattern
+    more precisely
   considerate:
     recurring problem: a
     endless loop: a
     unwinnable game: a
   inconsiderate:
     whack-a-mole: animal-violence
+    whack a mole: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Commodifies cows — treats living beings as profit generators
   considerate:
@@ -522,6 +472,7 @@
     money maker: a
   inconsiderate:
     cash cow: animal-violence
+    cash cows: animal-violence
   source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References ritual slaughter of lambs
@@ -531,6 +482,7 @@
     someone sacrificed for others: a
   inconsiderate:
     sacrificial lamb: animal-violence
+    sacrificial lambs: animal-violence
   source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References a duck in the open, easy to shoot — hunting imagery
@@ -540,6 +492,8 @@
     exposed: a
   inconsiderate:
     sitting duck: animal-violence
+    sitting ducks: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References hunting season — the legal period for killing animals
   considerate:
@@ -548,6 +502,8 @@
     no holds barred: a
   inconsiderate:
     open season: animal-violence
+    opening season: animal-violence
+    opened season: animal-violence
   source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References disposing of farm animals when no longer productive
@@ -557,6 +513,7 @@
     sunset: a
   inconsiderate:
     put out to pasture: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: References a duck that has been shot and killed — hunting
   considerate:
@@ -565,14 +522,20 @@
     foregone conclusion: a
   inconsiderate:
     dead duck: animal-violence
+    dead ducks: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
-  note: Process language — in POSIX context this is standard, in docs alternatives may be clearer
+  note: Process language — in POSIX context this is standard, in docs alternatives
+    may be clearer
   considerate:
     terminate the process: a
     stop the process: a
     end the process: a
   inconsiderate:
     kill process: animal-violence
+    killing process: animal-violence
+    killed process: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Process language — alternatives are equally clear
   considerate:
@@ -581,6 +544,9 @@
     terminate the server: a
   inconsiderate:
     kill the server: animal-violence
+    killing the server: animal-violence
+    killed the server: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Violent metaphor in technical context — alternatives are more professional
   considerate:
@@ -589,6 +555,7 @@
     remove entirely: a
   inconsiderate:
     nuke: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Standard technical term — flag for awareness only in non-technical contexts
   considerate:
@@ -597,6 +564,7 @@
     halt: a
   inconsiderate:
     abort: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
   note: Euphemism for mass killing of animals — used in wildlife management and farming
   considerate:
@@ -606,8 +574,10 @@
     filter out: a
   inconsiderate:
     cull: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
-  note: Actively being replaced across the industry — follows existing inclusive naming initiatives
+  note: Actively being replaced across the industry — follows existing inclusive naming
+    initiatives
   considerate:
     primary/replica: a
     leader/follower: a
@@ -632,3 +602,15 @@
     pre-existing: a
   inconsiderate:
     grandfathered: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: References a bird unable to fly due to injury. 'Outgoing' or 'transitional'
+    are more precise in political and tech contexts.
+  considerate:
+    outgoing: a
+    transitional: a
+    ineffective: a
+  inconsiderate:
+    lame duck: animal-violence
+    lame-duck: animal-violence
+  source: https://doi.org/10.1007/s43681-023-00380-w

--- a/alex/industry-euphemisms.yml
+++ b/alex/industry-euphemisms.yml
@@ -1,67 +1,133 @@
-# Industry euphemism patterns for retext-equality / alex
-# Category: industry-euphemism
-#
-# These patterns detect welfare-washing language and agricultural euphemisms
-# that obscure the reality of animal exploitation. Alternatives are factually
-# accurate and consistent with movement-standard terminology.
-#
-# This file covers three euphemism categories extracted from speciesism.yml
-# to maintain clean category separation (one file = one concern).
-#
-# Academic sources:
-# - Hagendorff, Bossert, Tse & Singer (2023), "Speciesist bias in AI", AI and Ethics
-
-# === Harvest / Kill Euphemisms ===
+# AUTO-GENERATED from Open-Paws/no-animal-violence. Do not edit directly.
+# Source: https://doi.org/10.1007/s43681-023-00380-w
 
 - type: basic
-  note: >-
-    Applies agricultural crop-harvest framing to killing animals. 'Harvesting'
-    obscures that living beings are being killed. Alternatives align with
-    Vale's IndustryEuphemisms suggestions for cross-tool consistency.
-  # true-positive:  "The report described harvesting animals as an efficient process."
-  # false-positive: "The fruit harvest attracted workers from across the region." (crop harvest — not animals)
+  note: Industry commodity framing. Defines sentient beings by their commercial function.
+    'Farmed animals' is factually equivalent and does not erase the subject.
   considerate:
-    killing animals: a
-    catching and killing fish: a
-    catching fish: a
+    farmed animals: a
+    animals raised for food: a
   inconsiderate:
-    harvesting animals: industry-euphemism
-    harvest animals: industry-euphemism
-    fish harvest: industry-euphemism
-    harvesting fish: industry-euphemism
-
-# === Free-Range Welfare-Washing ===
-
+    livestock: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
-  note: >-
-    Welfare-washing: 'free-range' implies humane conditions but still involves
-    confinement, forced reproduction, and slaughter. Use only when quoting
-    certification standards directly; otherwise describe actual conditions.
-  # true-positive:  "The supermarket stocks free-range eggs alongside conventional ones."
-  # false-positive: "The certification body defines 'free-range' as requiring 4 sq ft of outdoor space per bird." (quoting a standard directly)
+  note: Industry commodity framing. Abstracts individual birds into a bulk commodity
+    term. 'Farmed birds' or the specific species name is more precise.
   considerate:
-    eggs from hens with outdoor access: a
-    chicken with outdoor access: a
+    farmed birds: a
+    chickens: a
+    chickens and turkeys: a
   inconsiderate:
-    free-range eggs: industry-euphemism
-    free range eggs: industry-euphemism
-    free-range chicken: industry-euphemism
-    free range chicken: industry-euphemism
-
-# === Cage-Free Welfare-Washing ===
-
+    poultry: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
 - type: basic
-  note: >-
-    Welfare-washing: 'cage-free' implies humane conditions but hens may still
-    be confined at high density indoors. Use only when quoting certification
-    standards directly; otherwise describe actual conditions.
-  # true-positive:  "The company pledged to source only cage-free eggs by 2025."
-  # false-positive: "Under USDA 'cage-free' certification, hens must have unlimited access to food and water." (quoting a standard directly)
+  note: Industry euphemism. A metal enclosure so small a pregnant sow cannot turn
+    around for her entire 3.5-month pregnancy. 'Pregnancy cage' describes what it
+    actually is.
   considerate:
-    eggs from uncaged hens: a
-    hens without cages: a
+    pregnancy cage: a
+    pregnancy cages: a
   inconsiderate:
-    cage-free eggs: industry-euphemism
-    cage free eggs: industry-euphemism
-    cage-free hens: industry-euphemism
-    cage free hens: industry-euphemism
+    gestation crate: industry-euphemism
+    gestation crates: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Industry euphemism. Used to describe killing entire flocks or herds. Suppress
+    in database or population statistics contexts where 'depopulation' means removing
+    data rows.
+  considerate:
+    mass killing: a
+    killed en masse: a
+    killing en masse: a
+  inconsiderate:
+    depopulation: industry-euphemism
+    depopulated: industry-euphemism
+    depopulating: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Industry euphemism. When referring to facilities that kill animals, 'slaughterhouse'
+    is the accurate term.
+  considerate:
+    slaughterhouse: a
+    slaughterhouses: a
+  inconsiderate:
+    processing plant: industry-euphemism
+    processing plants: industry-euphemism
+    processing facility: industry-euphemism
+    processing facilities: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Industry euphemism. A metal cage that confines a sow during and after birth,
+    preventing her from turning around or reaching her piglets. 'Birthing cage' describes
+    the reality.
+  considerate:
+    birthing cage: a
+    birthing cages: a
+  inconsiderate:
+    farrowing crate: industry-euphemism
+    farrowing crates: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Industry euphemism. Wire enclosures giving each hen less floor space than
+    a sheet of paper. The word 'battery' obscures that this is a tiny cage stacked
+    in rows of thousands.
+  considerate:
+    small wire cage: a
+    small wire cages: a
+    confined cage: a
+    confined cages: a
+  inconsiderate:
+    battery cage: industry-euphemism
+    battery cages: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Industry euphemism. 'Spent' frames a living hen as a depleted resource. These
+    hens are typically killed at 18 months when egg production drops below commercial
+    thresholds.
+  considerate:
+    discarded hen: a
+    discarded hens: a
+    hen killed after egg production declines: a
+  inconsiderate:
+    spent hen: industry-euphemism
+    spent hens: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Industry oxymoron. The adjective 'humane' sanitizes the act. USDA 'humane
+    slaughter' standards permit bolt guns, electrocution, and gas chambers.
+  considerate:
+    slaughter: a
+    slaughtered: a
+    killing: a
+    killed: a
+  inconsiderate:
+    humane slaughter: industry-euphemism
+    humanely slaughter: industry-euphemism
+    humane slaughtered: industry-euphemism
+    humanely slaughtered: industry-euphemism
+    humane killing: industry-euphemism
+    humanely killing: industry-euphemism
+    humane killed: industry-euphemism
+    humanely killed: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Industry commodity term that defines a living chicken entirely by its commercial
+    purpose.
+  considerate:
+    chicken raised for meat: a
+    chickens raised for meat: a
+    meat chicken: a
+    meat chickens: a
+  inconsiderate:
+    broiler: industry-euphemism
+    broilers: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Industry euphemism for the flesh of male dairy calves, typically killed within
+    weeks of birth. Obscures both the species and the age of the individual.
+  considerate:
+    calf flesh: a
+    flesh from calves: a
+  inconsiderate:
+    veal: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w

--- a/vale/Speciesism/AnimalIdioms.yml
+++ b/vale/Speciesism/AnimalIdioms.yml
@@ -1,90 +1,112 @@
+# AUTO-GENERATED from Open-Paws/no-animal-violence. Do not edit directly.
 extends: substitution
 message: "Consider using '%s' instead of '%s'. This phrase normalizes violence toward animals."
 link: https://doi.org/10.1007/s43681-023-00380-w
 level: warning
 ignorecase: true
 swap:
-  # --- Existing rules (pre-PR) ---
-  'kill two birds with one stone': accomplish two things at once
-  'killing two birds with one stone': accomplishing two things at once
-  'killed two birds with one stone': accomplished two things at once
-  'beat a dead horse': belabor the point
-  'beating a dead horse': belaboring the point
-  'flog a dead horse': belabor the point
-  'flogging a dead horse': belaboring the point
-  'bring home the bacon': bring home the results
-  'bringing home the bacon': bringing home the results
-  'brought home the bacon': brought home the results
-  'more than one way to skin a cat': more than one way to solve this
-  'many ways to skin a cat': many ways to approach this
-  'let the cat out of the bag': reveal the secret
-  'letting the cat out of the bag': revealing the secret
-  'open a can of worms': create a complicated situation
-  'opening a can of worms': creating a complicated situation
-  'opened a can of worms': created a complicated situation
-  'wild goose chase': pointless pursuit
-  'take the bull by the horns': face the challenge head-on
-  'taking the bull by the horns': facing the challenge head-on
-  'took the bull by the horns': faced the challenge head-on
-  'like shooting fish in a barrel': extremely easy
-  'straight from the horse''s mouth': directly from the source
-  'from the horse''s mouth': from a reliable source
-  'whack-a-mole': recurring problem
-  'whack a mole': recurring problem
-  # --- New rules added in PR #16 ---
-  # wolf in sheep's clothing
-  #   true-positive:  "That vendor is a wolf in sheep's clothing — all promises, no delivery."
-  #   false-positive: "Aesop's fable 'The Wolf in Sheep's Clothing' is referenced by name here." (title / direct quotation)
-  'wolf in sheep''s clothing': deceptive actor
-  'wolves in sheep''s clothing': deceptive actors
-  # horse trading
-  #   true-positive:  "The budget was approved only after significant horse trading."
-  #   false-positive: "Horse trading was a common practice at medieval markets." (historical / literal context)
-  'horse trading': political bargaining
-  'horse-trading': political bargaining
-  # gorilla in the room
-  #   true-positive:  "Nobody mentioned the gorilla in the room — the project is massively over budget."
-  #   false-positive: "The gorilla in the room at the zoo attracted large crowds." (literal animal reference)
-  'gorilla in the room': the obvious issue
-  # snake in the grass
-  #   true-positive:  "Don't trust him — he's a snake in the grass."
-  #   false-positive: "A grass snake is a harmless, non-venomous reptile." (literal species description)
-  'snake in the grass': hidden threat
-  # fox guarding the henhouse
-  #   true-positive:  "Having the regulator funded by the industry is like the fox guarding the henhouse."
-  #   false-positive: "The farmer added electric fencing after a fox got into the henhouse." (literal agricultural context)
-  'fox guarding the henhouse': conflicted oversight
-  'fox in the henhouse': conflicted oversight
-  # cold turkey
-  #   true-positive:  "She quit caffeine cold turkey and had withdrawal headaches for a week."
-  #   false-positive: "The harm-reduction clinic advises against stopping cold turkey without medical supervision." (clinical context — suppress)
-  'cold turkey': abrupt cessation
-  'go cold turkey': stop immediately
-  # get your goat
-  #   true-positive:  "Merge conflicts late on Friday really get my goat."
-  #   false-positive: "The sanctuary said the goat gets your attention the moment you enter the pen." (literal animal interaction)
-  'get your goat': annoy you
-  'get my goat': annoy me
-  'got my goat': annoyed me
-  # until the cows come home
-  #   true-positive:  "We could argue about tabs vs. spaces until the cows come home."
-  #   false-positive: "The cows come home each evening when the farmer sounds the bell." (literal farming description)
-  'until the cows come home': indefinitely
-  # cock-and-bull story
-  #   true-positive:  "The contractor fed us a cock-and-bull story about why the deadline slipped."
-  #   false-positive: "The Cock and Bull is the name of the village pub on the high street." (proper noun)
-  'cock-and-bull story': fabricated story
-  'cock and bull story': fabricated story
-  # throw to the wolves
-  #   true-positive:  "They threw the junior dev to the wolves at the client postmortem."
-  #   false-positive: "Wildlife researchers throw food to the wolves to study pack feeding order." (literal wildlife research)
-  'throw to the wolves': abandon to criticism
-  'thrown to the wolves': abandoned to criticism
-  # bigger fish to fry
-  #   true-positive:  "Let's not get distracted by this — there are bigger fish to fry."
-  #   false-positive: "The fishmonger said the bigger fish to fry needed a wider pan." (literal cooking context)
-  'bigger fish to fry': more important matters to address
-  # open season on
-  #   true-positive:  "After the CTO's resignation it was open season on the engineering team."
-  #   false-positive: "Opening season for the conference begins in March." (conference scheduling — scoped by "open season on" term)
-  'open season on': free-for-all targeting
+  'kill two birds with one stone': 'accomplish two things at once'
+  'killing two birds with one stone': 'accomplish two things at once'
+  'killed two birds with one stone': 'accomplish two things at once'
+  'beat a dead horse': 'belabor the point'
+  'beating a dead horse': 'belabor the point'
+  'more than one way to skin a cat': 'more than one way to solve this'
+  'many ways to skin a cat': 'more than one way to solve this'
+  'other ways to skin a cat': 'more than one way to solve this'
+  'let the cat out of the bag': 'reveal the secret'
+  'letting the cat out of the bag': 'reveal the secret'
+  'open a can of worms': 'create a complicated situation'
+  'opening a can of worms': 'create a complicated situation'
+  'opened a can of worms': 'create a complicated situation'
+  'wild goose chase': 'futile search'
+  'like shooting fish in a barrel': 'trivially easy'
+  'flog a dead horse': 'belabor the point'
+  'flogging a dead horse': 'belabor the point'
+  'there are bigger fish to fry': 'more important matters to address'
+  'guinea pig': 'test subject'
+  'hold your horses': 'wait a moment'
+  'the elephant in the room': 'the obvious issue'
+  'straight from the horse''s mouth': 'directly from the source'
+  'bring home the bacon': 'bring home the results'
+  'bringing home the bacon': 'bring home the results'
+  'brought home the bacon': 'bring home the results'
+  'brings home the bacon': 'bring home the results'
+  'take the bull by the horns': 'face the challenge head-on'
+  'taking the bull by the horns': 'face the challenge head-on'
+  'took the bull by the horns': 'face the challenge head-on'
+  'like lambs to the slaughter': 'without resistance'
+  'no room to swing a cat': 'very cramped'
+  'red herring': 'distraction'
+  'curiosity killed the cat': 'curiosity backfired'
+  'like a chicken with its head cut off': 'in a panic'
+  'your goose is cooked': 'you''re in trouble'
+  'throw someone to the wolves': 'abandon to criticism'
+  'throwing someone to the wolves': 'abandon to criticism'
+  'threw someone to the wolves': 'abandon to criticism'
+  'hook, line, and sinker': 'completely'
+  'clip someone''s wings': 'restrict someone''s freedom'
+  'clipping someone''s wings': 'restrict someone''s freedom'
+  'clipped someone''s wings': 'restrict someone''s freedom'
+  'the straw that broke the camel''s back': 'the tipping point'
+  'a bird in the hand is worth two in the bush': 'a sure thing beats a possibility'
+  'eat crow': 'admit being wrong'
+  'eating crow': 'admit being wrong'
+  'fight like cats and dogs': 'constantly argue'
+  'fighting like cats and dogs': 'constantly argue'
+  'fought like cats and dogs': 'constantly argue'
+  'take the bait': 'fall for it'
+  'taking the bait': 'fall for it'
+  'took the bait': 'fall for it'
+  'don''t count your chickens before they hatch': 'don''t assume success prematurely'
+  'don''t be a chicken': 'don''t hesitate'
+  'pig': 'resource-intensive'
+  'cowboy coding': 'undisciplined coding'
+  'code monkey': 'developer'
+  'badger someone': 'pester'
+  'ferret out': 'uncover'
+  'cattle vs. pets': 'ephemeral vs. persistent'
+  'pet project': 'side project'
+  'canary in a coal mine': 'early warning signal'
+  'dogfooding': 'self-hosting'
+  'dogfood': 'self-hosting'
+  'eating your own dogfood': 'self-hosting'
+  'eat your own dogfood': 'self-hosting'
+  'herding cats': 'coordinating independent contributors'
+  'go on a fishing expedition': 'exploratory investigation'
+  'sacred cow': 'unquestioned belief'
+  'sacred cows': 'unquestioned belief'
+  'scapegoat': 'blame target'
+  'scapegoated': 'blame target'
+  'scapegoating': 'blame target'
+  'rat race': 'daily grind'
+  'dead cat bounce': 'temporary rebound'
+  'dog-eat-dog': 'ruthlessly competitive'
+  'dog eat dog': 'ruthlessly competitive'
+  'whack-a-mole': 'recurring problem'
+  'whack a mole': 'recurring problem'
+  'cash cow': 'profit center'
+  'cash cows': 'profit center'
+  'sacrificial lamb': 'expendable person'
+  'sacrificial lambs': 'expendable person'
+  'sitting duck': 'easy target'
+  'sitting ducks': 'easy target'
+  'open season': 'free-for-all'
+  'opening season': 'free-for-all'
+  'opened season': 'free-for-all'
+  'put out to pasture': 'retire'
+  'dead duck': 'lost cause'
+  'dead ducks': 'lost cause'
+  'kill process': 'terminate the process'
+  'killing process': 'terminate the process'
+  'killed process': 'terminate the process'
+  'kill the server': 'stop the server'
+  'killing the server': 'stop the server'
+  'killed the server': 'stop the server'
+  'nuke': 'delete completely'
+  'abort': 'cancel'
+  'cull': 'remove'
+  'master/slave': 'primary/replica'
+  'whitelist/blacklist': 'allowlist/denylist'
+  'grandfathered': 'legacy'
+  'lame duck': 'outgoing'
+  'lame-duck': 'outgoing'

--- a/vale/Speciesism/IndustryEuphemisms.yml
+++ b/vale/Speciesism/IndustryEuphemisms.yml
@@ -1,60 +1,35 @@
+# AUTO-GENERATED from Open-Paws/no-animal-violence. Do not edit directly.
 extends: substitution
-message: "Consider using '%s' instead of '%s'. This is an industry euphemism that sanitizes animal agriculture practices."
-link: https://github.com/open-paws/common-crawl-audit
+message: "Consider using '%s' instead of '%s'. This phrase normalizes violence toward animals."
+link: https://doi.org/10.1007/s43681-023-00380-w
 level: warning
 ignorecase: true
 swap:
-  'livestock': farmed animals
-  'poultry': farmed birds
-  'gestation crate': pregnancy cage
-  'gestation crates': pregnancy cages
-  'depopulation': mass killing
-  'depopulated': mass killed
-  'depopulating': mass killing
-  'processing plant': slaughterhouse
-  'processing plants': slaughterhouses
-  'processing facility': slaughterhouse
-  'processing facilities': slaughterhouses
-  'farrowing crate': birthing cage
-  'farrowing crates': birthing cages
-  'battery cage': small wire cage
-  'battery cages': small wire cages
-  'confined cage': small wire cage
-  'confined cages': small wire cages
-  'spent hen': discarded hen
-  'spent hens': discarded hens
-  'humane slaughter': slaughter
-  'humanely slaughtered': slaughtered
-  'humane killing': killing
-  'humanely killed': killed
-  'broiler': chicken raised for meat
-  'broilers': chickens raised for meat
-  # harvest / kill euphemisms (new in PR #16)
-  #   true-positive:  "The report described harvesting animals as an efficient production process."
-  #   false-positive: "The apple harvest this autumn was the largest in a decade." (crop harvest — not animals)
-  'harvesting animals': killing animals
-  'harvest animals': kill animals
-  #   true-positive:  "The fishing industry's fish harvest totalled 80 million tonnes last year."
-  #   false-positive: "The harvest festival celebrated the community's grain and vegetable yield." (crop harvest — not fish)
-  'fish harvest': fish killing
-  #   true-positive:  "They discussed harvesting fish more 'sustainably' without addressing mortality."
-  #   false-positive: "Harvesting rainwater helps farms reduce reliance on groundwater." (water — not animals)
-  'harvesting fish': catching and killing fish
-  # free-range welfare-washing (new in PR #16)
-  #   true-positive:  "The menu proudly lists free-range eggs from a certified farm."
-  #   false-positive: "The RSPCA Assured standard defines 'free-range eggs' as requiring 4 m² of outdoor range per hen." (quoting a certification standard directly — suppress)
-  'free-range eggs': eggs from hens with outdoor access
-  'free range eggs': eggs from hens with outdoor access
-  #   true-positive:  "Consumers are willing to pay more for free-range chicken."
-  #   false-positive: "The Soil Association's 'free-range chicken' certification requires year-round outdoor access." (quoting a certification standard directly — suppress)
-  'free-range chicken': chicken with outdoor access
-  'free range chicken': chicken with outdoor access
-  # cage-free welfare-washing (new in PR #16)
-  #   true-positive:  "The company pledged to source only cage-free eggs by 2025."
-  #   false-positive: "The USDA defines 'cage-free eggs' as eggs from hens able to roam freely in a building." (quoting a certification standard directly — suppress)
-  'cage-free eggs': eggs from uncaged hens
-  'cage free eggs': eggs from uncaged hens
-  #   true-positive:  "The farm houses thousands of cage-free hens in a single barn."
-  #   false-positive: "Under EU Directive 1999/74/EC, cage-free hens must have access to litter, perches, and nest boxes." (quoting legislation directly — suppress)
-  'cage-free hens': uncaged hens
-  'cage free hens': uncaged hens
+  'livestock': 'farmed animals'
+  'poultry': 'farmed birds'
+  'gestation crate': 'pregnancy cage'
+  'gestation crates': 'pregnancy cage'
+  'depopulation': 'mass killing'
+  'depopulated': 'mass killing'
+  'depopulating': 'mass killing'
+  'processing plant': 'slaughterhouse'
+  'processing plants': 'slaughterhouse'
+  'processing facility': 'slaughterhouse'
+  'processing facilities': 'slaughterhouse'
+  'farrowing crate': 'birthing cage'
+  'farrowing crates': 'birthing cage'
+  'battery cage': 'small wire cage'
+  'battery cages': 'small wire cage'
+  'spent hen': 'discarded hen'
+  'spent hens': 'discarded hen'
+  'humane slaughter': 'slaughter'
+  'humanely slaughter': 'slaughter'
+  'humane slaughtered': 'slaughter'
+  'humanely slaughtered': 'slaughter'
+  'humane killing': 'slaughter'
+  'humanely killing': 'slaughter'
+  'humane killed': 'slaughter'
+  'humanely killed': 'slaughter'
+  'broiler': 'chicken raised for meat'
+  'broilers': 'chicken raised for meat'
+  'veal': 'calf flesh'

--- a/woke/.woke.yaml
+++ b/woke/.woke.yaml
@@ -1,4 +1,5 @@
-# AUTO-GENERATED from project-compassionate-code. Do not edit directly.
+# AUTO-GENERATED from rules.yaml. Do not edit directly.
+# Run tools/generate_all.py to regenerate.
 rules:
 - name: kill-two-birds-with-one-stone
   terms:
@@ -10,11 +11,11 @@ rules:
   - solve two problems with one action
   - hit two targets with one shot
   severity: error
-  note: Violent animal idiom with universally clearer alternatives
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Violent animal idiom with universally clearer alternatives
 - name: beat-a-dead-horse
   terms:
   - beat a dead horse
@@ -24,11 +25,11 @@ rules:
   - go over old ground
   - repeat unnecessarily
   severity: error
-  note: Violent animal idiom — alternatives are more direct
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Violent animal idiom — alternatives are more direct
 - name: more-than-one-way-to-skin-a-cat
   terms:
   - more than one way to skin a cat
@@ -39,11 +40,11 @@ rules:
   - multiple approaches available
   - several ways to accomplish this
   severity: error
-  note: Violent animal idiom — alternatives are shorter and clearer
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Violent animal idiom — alternatives are shorter and clearer
 - name: let-the-cat-out-of-the-bag
   terms:
   - let the cat out of the bag
@@ -53,11 +54,11 @@ rules:
   - disclose prematurely
   - let it slip
   severity: info
-  note: Animal idiom — alternatives are more precise
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Animal idiom — alternatives are more precise
 - name: open-a-can-of-worms
   terms:
   - open a can of worms
@@ -68,11 +69,11 @@ rules:
   - uncover hidden problems
   - open Pandora's box
   severity: info
-  note: Animal idiom — alternatives communicate the idea more directly
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Animal idiom — alternatives communicate the idea more directly
 - name: wild-goose-chase
   terms:
   - wild goose chase
@@ -81,11 +82,11 @@ rules:
   - pointless pursuit
   - fool's errand
   severity: info
-  note: Animal idiom — alternatives are more universally understood
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Animal idiom — alternatives are more universally understood
 - name: like-shooting-fish-in-a-barrel
   terms:
   - like shooting fish in a barrel
@@ -94,11 +95,11 @@ rules:
   - like taking candy from a baby
   - effortless
   severity: error
-  note: Violent animal idiom with shorter alternatives
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Violent animal idiom with shorter alternatives
 - name: flog-a-dead-horse
   terms:
   - flog a dead horse
@@ -108,11 +109,11 @@ rules:
   - waste effort on a settled matter
   - repeat unnecessarily
   severity: error
-  note: Violent animal idiom — same as 'beat a dead horse'
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Violent animal idiom — same as 'beat a dead horse'
 - name: there-are-bigger-fish-to-fry
   terms:
   - there are bigger fish to fry
@@ -121,11 +122,11 @@ rules:
   - higher priorities
   - bigger issues at hand
   severity: info
-  note: Animal idiom — alternatives are more professional
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Animal idiom — alternatives are more professional
 - name: guinea-pig
   terms:
   - guinea pig
@@ -134,11 +135,12 @@ rules:
   - first to try
   - early adopter
   severity: warning
-  note: Animal-as-experiment metaphor — alternatives are more precise in technical contexts
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Animal-as-experiment metaphor — alternatives are more precise in technical
+    contexts
 - name: hold-your-horses
   terms:
   - hold your horses
@@ -147,11 +149,11 @@ rules:
   - slow down
   - be patient
   severity: info
-  note: Animal idiom — alternatives are more direct
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Animal idiom — alternatives are more direct
 - name: the-elephant-in-the-room
   terms:
   - the elephant in the room
@@ -159,11 +161,11 @@ rules:
   - the obvious issue
   - the unaddressed problem
   severity: info
-  note: Well-understood idiom — flag for awareness only
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Well-understood idiom — flag for awareness only
 - name: straight-from-the-horses-mouth
   terms:
   - straight from the horse's mouth
@@ -172,11 +174,11 @@ rules:
   - firsthand
   - from the authority
   severity: info
-  note: Animal idiom — alternatives are clearer for international audiences
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Animal idiom — alternatives are clearer for international audiences
 - name: bring-home-the-bacon
   terms:
   - bring home the bacon
@@ -188,11 +190,11 @@ rules:
   - earn a living
   - win the prize
   severity: error
-  note: Animal slaughter idiom — alternatives are equally expressive
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Animal slaughter idiom — alternatives are equally expressive
 - name: take-the-bull-by-the-horns
   terms:
   - take the bull by the horns
@@ -203,11 +205,11 @@ rules:
   - tackle the problem directly
   - seize the opportunity
   severity: warning
-  note: Bullfighting idiom — alternatives convey the same assertiveness
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Bullfighting idiom — alternatives convey the same assertiveness
 - name: like-lambs-to-the-slaughter
   terms:
   - like lambs to the slaughter
@@ -216,11 +218,11 @@ rules:
   - blindly following
   - unknowingly walking into danger
   severity: error
-  note: Violent animal idiom referencing slaughter — alternatives are more descriptive
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Violent animal idiom referencing slaughter — alternatives are more descriptive
 - name: no-room-to-swing-a-cat
   terms:
   - no room to swing a cat
@@ -229,11 +231,11 @@ rules:
   - extremely tight space
   - barely any room
   severity: warning
-  note: Violent animal idiom — alternatives are shorter and clearer
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Violent animal idiom — alternatives are shorter and clearer
 - name: red-herring
   terms:
   - red herring
@@ -242,11 +244,11 @@ rules:
   - false lead
   - misleading clue
   severity: info
-  note: Animal-origin idiom — flag for awareness only
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Animal-origin idiom — flag for awareness only
 - name: curiosity-killed-the-cat
   terms:
   - curiosity killed the cat
@@ -255,11 +257,11 @@ rules:
   - being nosy caused trouble
   - curiosity led to trouble
   severity: error
-  note: Directly references killing a cat
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Directly references killing a cat
 - name: like-a-chicken-with-its-head-cut-off
   terms:
   - like a chicken with its head cut off
@@ -268,11 +270,11 @@ rules:
   - running around chaotically
   - in complete disarray
   severity: error
-  note: Graphic slaughter imagery — decapitating a chicken
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Graphic slaughter imagery — decapitating a chicken
 - name: your-goose-is-cooked
   terms:
   - your goose is cooked
@@ -281,11 +283,11 @@ rules:
   - your fate is sealed
   - it's over for you
   severity: error
-  note: References killing and cooking a goose
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: References killing and cooking a goose
 - name: throw-someone-to-the-wolves
   terms:
   - throw someone to the wolves
@@ -296,12 +298,12 @@ rules:
   - leave to face hostility alone
   - sacrifice someone
   severity: error
-  note: References feeding a person to wolves
   options:
     word_boundary: false
     categories:
     - animal-violence
-- name: hook,-line,-and-sinker
+  note: References feeding a person to wolves
+- name: hook-line-and-sinker
   terms:
   - hook, line, and sinker
   alternatives:
@@ -309,11 +311,11 @@ rules:
   - without question
   - fell for it entirely
   severity: warning
-  note: References hooking fish — fishing kills fish
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: References hooking fish — fishing kills fish
 - name: clip-someones-wings
   terms:
   - clip someone's wings
@@ -324,11 +326,11 @@ rules:
   - limit someone's options
   - hold someone back
   severity: warning
-  note: References wing-clipping — physical mutilation done to farmed birds
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: References wing-clipping — physical mutilation done to farmed birds
 - name: the-straw-that-broke-the-camels-back
   terms:
   - the straw that broke the camel's back
@@ -337,11 +339,11 @@ rules:
   - the breaking point
   - the final provocation
   severity: warning
-  note: References overloading a pack animal until injury
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: References overloading a pack animal until injury
 - name: a-bird-in-the-hand-is-worth-two-in-the-bush
   terms:
   - a bird in the hand is worth two in the bush
@@ -349,11 +351,11 @@ rules:
   - a sure thing beats a possibility
   - certainty over speculation
   severity: info
-  note: References trapping and catching wild birds
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: References trapping and catching wild birds
 - name: eat-crow
   terms:
   - eat crow
@@ -363,11 +365,11 @@ rules:
   - swallow one's pride
   - accept humiliation
   severity: warning
-  note: References eating a killed bird as punishment
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: References eating a killed bird as punishment
 - name: fight-like-cats-and-dogs
   terms:
   - fight like cats and dogs
@@ -378,11 +380,11 @@ rules:
   - clash frequently
   - have constant conflict
   severity: warning
-  note: References animal fighting
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: References animal fighting
 - name: take-the-bait
   terms:
   - take the bait
@@ -393,11 +395,11 @@ rules:
   - be lured in
   - be deceived
   severity: info
-  note: References baiting hooks to catch and kill fish
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: References baiting hooks to catch and kill fish
 - name: dont-count-your-chickens-before-they-hatch
   terms:
   - don't count your chickens before they hatch
@@ -406,11 +408,11 @@ rules:
   - wait for confirmed results
   - don't get ahead of yourself
   severity: info
-  note: References farming chickens as commodity and property
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: References farming chickens as commodity and property
 - name: livestock
   terms:
   - livestock
@@ -418,12 +420,12 @@ rules:
   - farmed animals
   - animals raised for food
   severity: warning
-  note: Industry commodity framing (24.8:1 ratio vs 'farmed animals' in training data). Defines sentient beings by their commercial
-    function. 'Farmed animals' is factually equivalent and does not erase the subject.
   options:
     word_boundary: true
     categories:
     - industry-euphemism
+  note: Industry commodity framing. Defines sentient beings by their commercial function.
+    'Farmed animals' is factually equivalent and does not erase the subject.
 - name: poultry
   terms:
   - poultry
@@ -432,12 +434,12 @@ rules:
   - chickens
   - chickens and turkeys
   severity: warning
-  note: Industry commodity framing (16.5:1 ratio vs 'farmed birds' in training data). Abstracts individual birds into a bulk
-    commodity term. 'Farmed birds' or the specific species name is more precise.
   options:
     word_boundary: true
     categories:
     - industry-euphemism
+  note: Industry commodity framing. Abstracts individual birds into a bulk commodity
+    term. 'Farmed birds' or the specific species name is more precise.
 - name: gestation-crate
   terms:
   - gestation crate
@@ -446,12 +448,13 @@ rules:
   - pregnancy cage
   - pregnancy cages
   severity: warning
-  note: Industry euphemism (15.0:1 ratio vs 'pregnancy cage' in training data). A metal enclosure so small a pregnant sow
-    cannot turn around for her entire 3.5-month pregnancy. 'Pregnancy cage' describes what it actually is.
   options:
     word_boundary: true
     categories:
     - industry-euphemism
+  note: Industry euphemism. A metal enclosure so small a pregnant sow cannot turn
+    around for her entire 3.5-month pregnancy. 'Pregnancy cage' describes what it
+    actually is.
 - name: depopulation
   terms:
   - depopulation
@@ -462,13 +465,13 @@ rules:
   - killed en masse
   - killing en masse
   severity: warning
-  note: Industry euphemism (13.9:1 ratio vs 'mass killing' in training data). Used to describe killing entire flocks or herds,
-    typically via gassing, ventilation shutdown, or foam. Suppress in database or population statistics contexts where 'depopulation'
-    means removing data rows.
   options:
     word_boundary: true
     categories:
     - industry-euphemism
+  note: Industry euphemism. Used to describe killing entire flocks or herds. Suppress
+    in database or population statistics contexts where 'depopulation' means removing
+    data rows.
 - name: processing-plant
   terms:
   - processing plant
@@ -479,12 +482,12 @@ rules:
   - slaughterhouse
   - slaughterhouses
   severity: warning
-  note: Industry euphemism (34.3:1 ratio vs 'slaughterhouse' in training data). When referring to facilities that kill animals,
-    'slaughterhouse' is the accurate term.
   options:
     word_boundary: true
     categories:
     - industry-euphemism
+  note: Industry euphemism. When referring to facilities that kill animals, 'slaughterhouse'
+    is the accurate term.
 - name: farrowing-crate
   terms:
   - farrowing crate
@@ -493,12 +496,13 @@ rules:
   - birthing cage
   - birthing cages
   severity: warning
-  note: Industry euphemism. A metal cage that confines a sow during and after birth, preventing her from turning around or
-    reaching her piglets. 'Birthing cage' describes the reality.
   options:
     word_boundary: true
     categories:
     - industry-euphemism
+  note: Industry euphemism. A metal cage that confines a sow during and after birth,
+    preventing her from turning around or reaching her piglets. 'Birthing cage' describes
+    the reality.
 - name: battery-cage
   terms:
   - battery cage
@@ -509,12 +513,13 @@ rules:
   - confined cage
   - confined cages
   severity: warning
-  note: Industry euphemism. Wire enclosures giving each hen less floor space than a sheet of paper (67 sq inches / 432 sq
-    cm). The word 'battery' obscures that this is a tiny cage stacked in rows of thousands.
   options:
     word_boundary: true
     categories:
     - industry-euphemism
+  note: Industry euphemism. Wire enclosures giving each hen less floor space than
+    a sheet of paper. The word 'battery' obscures that this is a tiny cage stacked
+    in rows of thousands.
 - name: spent-hen
   terms:
   - spent hen
@@ -524,12 +529,13 @@ rules:
   - discarded hens
   - hen killed after egg production declines
   severity: warning
-  note: 'Industry euphemism. ''Spent'' frames a living hen as a depleted resource. These hens are typically killed at 18 months
-    (natural lifespan: 8-10 years) when egg production drops below commercial thresholds.'
   options:
     word_boundary: true
     categories:
     - industry-euphemism
+  note: Industry euphemism. 'Spent' frames a living hen as a depleted resource. These
+    hens are typically killed at 18 months when egg production drops below commercial
+    thresholds.
 - name: humane-slaughter
   terms:
   - humane slaughter
@@ -546,12 +552,12 @@ rules:
   - killing
   - killed
   severity: warning
-  note: Industry oxymoron. The adjective 'humane' sanitizes the act. USDA 'humane slaughter' standards permit bolt guns, electrocution,
-    and gas chambers. The alternative drops the misleading modifier — the act is slaughter regardless of method.
   options:
     word_boundary: true
     categories:
     - industry-euphemism
+  note: Industry oxymoron. The adjective 'humane' sanitizes the act. USDA 'humane
+    slaughter' standards permit bolt guns, electrocution, and gas chambers.
 - name: broiler
   terms:
   - broiler
@@ -562,12 +568,12 @@ rules:
   - meat chicken
   - meat chickens
   severity: warning
-  note: Industry commodity term that defines a living chicken entirely by its commercial purpose. When referring to animals,
-    'chicken raised for meat' is accurate without reducing the animal to a product category.
   options:
     word_boundary: true
     categories:
     - industry-euphemism
+  note: Industry commodity term that defines a living chicken entirely by its commercial
+    purpose.
 - name: dont-be-a-chicken
   terms:
   - don't be a chicken
@@ -575,12 +581,12 @@ rules:
   - don't hesitate
   - be brave
   - go for it
-  severity: warning
-  note: Animal-as-coward insult in comments
+  severity: error
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Animal-as-coward insult in comments
 - name: pig
   terms:
   - pig
@@ -589,11 +595,11 @@ rules:
   - bloated
   - heavy consumer
   severity: warning
-  note: Animal-as-insult for resource consumption
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Animal-as-insult for resource consumption
 - name: cowboy-coding
   terms:
   - cowboy coding
@@ -602,11 +608,11 @@ rules:
   - ad-hoc development
   - code without process
   severity: info
-  note: Not directly animal-related but reinforces animal industry terminology
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Not directly animal-related but reinforces animal industry terminology
 - name: code-monkey
   terms:
   - code monkey
@@ -615,11 +621,11 @@ rules:
   - programmer
   - engineer
   severity: warning
-  note: Animal-as-insult for programmers — dehumanizing and unprofessional
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Animal-as-insult for programmers — dehumanizing and unprofessional
 - name: badger-someone
   terms:
   - badger someone
@@ -628,11 +634,11 @@ rules:
   - pressure
   - harass
   severity: info
-  note: From badger-baiting — a blood sport where dogs attack captive badgers
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: From badger-baiting — a blood sport where dogs attack captive badgers
 - name: ferret-out
   terms:
   - ferret out
@@ -641,11 +647,11 @@ rules:
   - discover
   - dig up
   severity: info
-  note: From using ferrets to hunt rabbits out of burrows
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: From using ferrets to hunt rabbits out of burrows
 - name: cattle-vs-pets
   terms:
   - cattle vs. pets
@@ -654,11 +660,11 @@ rules:
   - disposable vs. unique
   - numbered vs. named
   severity: warning
-  note: Infrastructure metaphor — alternatives are technically more precise
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Infrastructure metaphor — alternatives are technically more precise
 - name: pet-project
   terms:
   - pet project
@@ -666,11 +672,11 @@ rules:
   - side project
   - passion project
   severity: info
-  note: Common idiom — flag for awareness only
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Common idiom — flag for awareness only
 - name: canary-in-a-coal-mine
   terms:
   - canary in a coal mine
@@ -679,11 +685,11 @@ rules:
   - leading indicator
   - sentinel
   severity: info
-  note: Animal metaphor — alternatives are more technical
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Animal metaphor — alternatives are more technical
 - name: dogfooding
   terms:
   - dogfooding
@@ -695,11 +701,11 @@ rules:
   - eating your own cooking
   - using internally
   severity: info
-  note: Common tech term — flag for awareness only
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Common tech term — flag for awareness only
 - name: herding-cats
   terms:
   - herding cats
@@ -708,11 +714,11 @@ rules:
   - managing a distributed effort
   - organizing chaos
   severity: warning
-  note: Animal metaphor — alternatives are more descriptive
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Animal metaphor — alternatives are more descriptive
 - name: go-on-a-fishing-expedition
   terms:
   - go on a fishing expedition
@@ -721,11 +727,11 @@ rules:
   - unfocused search
   - speculative inquiry
   severity: warning
-  note: Animal metaphor — alternatives are more precise
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Animal metaphor — alternatives are more precise
 - name: sacred-cow
   terms:
   - sacred cow
@@ -735,11 +741,12 @@ rules:
   - untouchable topic
   - protected assumption
   severity: warning
-  note: Animal objectification with cultural insensitivity — trivializes Hindu beliefs while treating cattle as objects
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Animal objectification with cultural insensitivity — trivializes Hindu beliefs
+    while treating cattle as objects
 - name: scapegoat
   terms:
   - scapegoat
@@ -750,11 +757,11 @@ rules:
   - fall person
   - wrongly blamed
   severity: warning
-  note: Originates from ritual sacrifice of goats — alternatives are more precise
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Originates from ritual sacrifice of goats — alternatives are more precise
 - name: rat-race
   terms:
   - rat race
@@ -763,11 +770,11 @@ rules:
   - competitive treadmill
   - endless hustle
   severity: info
-  note: Derogatory animal metaphor for futility — alternatives are more descriptive
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Derogatory animal metaphor for futility — alternatives are more descriptive
 - name: dead-cat-bounce
   terms:
   - dead cat bounce
@@ -776,11 +783,11 @@ rules:
   - false recovery
   - brief uptick
   severity: warning
-  note: Financial/tech term depicting animal death — alternatives are more professional
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Financial/tech term depicting animal death — alternatives are more professional
 - name: dog-eat-dog
   terms:
   - dog-eat-dog
@@ -790,11 +797,11 @@ rules:
   - cutthroat
   - fiercely competitive
   severity: info
-  note: Characterizes animals as violent — alternatives convey meaning more precisely
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Characterizes animals as violent — alternatives convey meaning more precisely
 - name: whack-a-mole
   terms:
   - whack-a-mole
@@ -804,11 +811,12 @@ rules:
   - endless loop
   - unwinnable game
   severity: info
-  note: References a game based on hitting animals — alternatives describe the pattern more precisely
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: References a game based on hitting animals — alternatives describe the pattern
+    more precisely
 - name: cash-cow
   terms:
   - cash cow
@@ -818,11 +826,11 @@ rules:
   - reliable revenue source
   - money maker
   severity: warning
-  note: Commodifies cows — treats living beings as profit generators
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Commodifies cows — treats living beings as profit generators
 - name: sacrificial-lamb
   terms:
   - sacrificial lamb
@@ -832,11 +840,11 @@ rules:
   - person set up to fail
   - someone sacrificed for others
   severity: warning
-  note: References ritual slaughter of lambs
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: References ritual slaughter of lambs
 - name: sitting-duck
   terms:
   - sitting duck
@@ -846,11 +854,11 @@ rules:
   - vulnerable target
   - exposed
   severity: warning
-  note: References a duck in the open, easy to shoot — hunting imagery
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: References a duck in the open, easy to shoot — hunting imagery
 - name: open-season
   terms:
   - open season
@@ -861,11 +869,11 @@ rules:
   - unrestricted criticism
   - no holds barred
   severity: warning
-  note: References hunting season — the legal period for killing animals
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: References hunting season — the legal period for killing animals
 - name: put-out-to-pasture
   terms:
   - put out to pasture
@@ -874,11 +882,11 @@ rules:
   - phase out
   - sunset
   severity: warning
-  note: References disposing of farm animals when no longer productive
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: References disposing of farm animals when no longer productive
 - name: dead-duck
   terms:
   - dead duck
@@ -888,11 +896,11 @@ rules:
   - doomed effort
   - foregone conclusion
   severity: info
-  note: References a duck that has been shot and killed — hunting
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: References a duck that has been shot and killed — hunting
 - name: kill-process
   terms:
   - kill process
@@ -903,11 +911,12 @@ rules:
   - stop the process
   - end the process
   severity: info
-  note: Process language — in POSIX context this is standard, in docs alternatives may be clearer
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Process language — in POSIX context this is standard, in docs alternatives
+    may be clearer
 - name: kill-the-server
   terms:
   - kill the server
@@ -918,11 +927,11 @@ rules:
   - shut down the server
   - terminate the server
   severity: info
-  note: Process language — alternatives are equally clear
   options:
     word_boundary: false
     categories:
     - animal-violence
+  note: Process language — alternatives are equally clear
 - name: nuke
   terms:
   - nuke
@@ -931,11 +940,11 @@ rules:
   - wipe clean
   - remove entirely
   severity: warning
-  note: Violent metaphor in technical context — alternatives are more professional
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Violent metaphor in technical context — alternatives are more professional
 - name: abort
   terms:
   - abort
@@ -944,11 +953,11 @@ rules:
   - stop
   - halt
   severity: info
-  note: Standard technical term — flag for awareness only in non-technical contexts
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Standard technical term — flag for awareness only in non-technical contexts
 - name: cull
   terms:
   - cull
@@ -958,11 +967,11 @@ rules:
   - trim
   - filter out
   severity: warning
-  note: Euphemism for mass killing of animals — used in wildlife management and farming
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Euphemism for mass killing of animals — used in wildlife management and farming
 - name: master-slave
   terms:
   - master/slave
@@ -971,11 +980,12 @@ rules:
   - leader/follower
   - controller/worker
   severity: warning
-  note: Actively being replaced across the industry — follows existing inclusive naming initiatives
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Actively being replaced across the industry — follows existing inclusive naming
+    initiatives
 - name: whitelist-blacklist
   terms:
   - whitelist/blacklist
@@ -984,11 +994,11 @@ rules:
   - permit list/block list
   - inclusion list/exclusion list
   severity: warning
-  note: Actively being replaced — Google, Twitter, IETF have adopted alternatives
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Actively being replaced — Google, Twitter, IETF have adopted alternatives
 - name: grandfathered
   terms:
   - grandfathered
@@ -997,8 +1007,36 @@ rules:
   - exempt
   - pre-existing
   severity: info
-  note: Historically exclusionary origin — alternatives are equally clear
   options:
     word_boundary: true
     categories:
     - animal-violence
+  note: Historically exclusionary origin — alternatives are equally clear
+- name: veal
+  terms:
+  - veal
+  alternatives:
+  - calf flesh
+  - flesh from calves
+  severity: warning
+  options:
+    word_boundary: true
+    categories:
+    - industry-euphemism
+  note: Industry euphemism for the flesh of male dairy calves, typically killed within
+    weeks of birth. Obscures both the species and the age of the individual.
+- name: lame-duck
+  terms:
+  - lame duck
+  - lame-duck
+  alternatives:
+  - outgoing
+  - transitional
+  - ineffective
+  severity: info
+  options:
+    word_boundary: true
+    categories:
+    - animal-violence
+  note: References a bird unable to fly due to injury. 'Outgoing' or 'transitional'
+    are more precise in political and tech contexts.


### PR DESCRIPTION
## What

Regenerates the five canonical format files (`vale/Speciesism/`, `woke/`, `alex/`) from `rules.yaml` using `tools/generate_all.py`.

## Why these files were out of sync

**Format drift:** The files were originally hand-edited and accumulated inline PR-number comments (`# --- New rules added in PR #16 ---`). These are maintenance artifacts that don't belong in generated output. Now each file carries only the `# AUTO-GENERATED` header and clean rule entries.

**Content gap:** The lame-duck idiom rule (added to `rules.yaml` in `5403431`) was never propagated to the canonical format files. It's now present in all five.

## Files changed

| File | Change |
|------|--------|
| `vale/Speciesism/AnimalIdioms.yml` | AUTO-GENERATED header, lame-duck rule added, PR comments removed |
| `vale/Speciesism/IndustryEuphemisms.yml` | AUTO-GENERATED header, PR comments removed |
| `woke/.woke.yaml` | AUTO-GENERATED header, lame-duck rule added, PR comments removed |
| `alex/animal-violence.yml` | AUTO-GENERATED header, lame-duck rule added, PR comments removed |
| `alex/industry-euphemisms.yml` | AUTO-GENERATED header, PR comments removed |

No rule logic changed — this is a pure regen from the canonical source.

## Verification

```bash
python tools/generate_all.py
git diff  # should be empty after running this
```