### PR TITLE
fix: close superseded sync PRs + add canary/duck/monkey tech terms

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -1101,12 +1101,13 @@ rules:
       - canary deployment
       - canary deploy
       - canary release
+      - canary-deployment
     alternatives: []
     severity: info
     category: animal-violence
     note: Deployment strategy named after canaries used as early warning signals in coal mines. Standard tech term — flag for awareness only, not a candidate for renaming.
     word_boundary: true
-    regex: "canary\\s+(deploy(ment|ed)?|release)"
+    regex: "canary[\\s-]+(deploy(ment|ed)?|release)"
     context_suppressions: []
 
   - name: duck-typing

--- a/rules.yaml
+++ b/rules.yaml
@@ -1095,3 +1095,42 @@ rules:
     word_boundary: true
     regex: "lame[\\s-]duck"
     context_suppressions: []
+
+  - name: canary-deployment
+    terms:
+      - canary deployment
+      - canary deploy
+      - canary release
+    alternatives: []
+    severity: info
+    category: animal-violence
+    note: Deployment strategy named after canaries used as early warning signals in coal mines. Standard tech term — flag for awareness only, not a candidate for renaming.
+    word_boundary: true
+    regex: "canary\\s+(deploy(ment|ed)?|release)"
+    context_suppressions: []
+
+  - name: duck-typing
+    terms:
+      - duck typing
+      - duck-typed
+    alternatives: []
+    severity: info
+    category: animal-violence
+    note: Programming concept from 'if it walks like a duck, it's a duck'. Standard tech term — flag for awareness only, not a candidate for renaming.
+    word_boundary: true
+    regex: "duck[\\s-]typ(ing|ed|e)"
+    context_suppressions: []
+
+  - name: monkey-patching
+    terms:
+      - monkey patching
+      - monkey patch
+      - monkey-patching
+      - monkey-patch
+    alternatives: []
+    severity: info
+    category: animal-violence
+    note: Runtime code modification technique derived from 'guerrilla patching'. Standard tech term — flag for awareness only, not a candidate for renaming.
+    word_boundary: true
+    regex: "monkey[\\s-]patch(ing|ed|es)?"
+    context_suppressions: []

--- a/tools/propagate.py
+++ b/tools/propagate.py
@@ -10,6 +10,7 @@ Environment variables required:
 import json
 import os
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -131,8 +132,8 @@ def close_superseded_prs(repo: str, new_branch: str, canonical_sha: str, gh_env:
                  " All changes from this PR are included in the newer sync."],
                 env=gh_env, capture_output=True,
             )
-    except (subprocess.CalledProcessError, json.JSONDecodeError):
-        pass  # Non-fatal: worst case the old PR stays open
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        print(f"Warning: could not close superseded PRs in {repo}: {exc}", file=sys.stderr, flush=True)
 
 
 def propagate_repo(config: dict, sync_branch: str, canonical_sha: str, dry_run: bool) -> dict:
@@ -170,7 +171,6 @@ def propagate_repo(config: dict, sync_branch: str, canonical_sha: str, dry_run: 
                 return result
 
             gh_env = {**os.environ, "GH_TOKEN": token}
-            close_superseded_prs(repo, sync_branch, canonical_sha, gh_env)
 
             run(["git", "checkout", "-b", sync_branch], cwd=tmpdir)
             run(["git", "config", "user.email", "sync-bot@openpaws.ai"], cwd=tmpdir)
@@ -213,6 +213,7 @@ def propagate_repo(config: dict, sync_branch: str, canonical_sha: str, dry_run: 
             )
             result["pr_url"] = pr_result.stdout.strip()
             result["status"] = "pr_opened"
+            close_superseded_prs(repo, sync_branch, canonical_sha, gh_env)
 
         except subprocess.CalledProcessError as exc:
             result["status"] = "error"

--- a/tools/propagate.py
+++ b/tools/propagate.py
@@ -7,6 +7,7 @@ Environment variables required:
   SHORT_SHA      Short SHA for branch names
   DRY_RUN        'true' to skip push and PR creation
 """
+import json
 import os
 import subprocess
 import tempfile
@@ -107,6 +108,33 @@ def run(cmd, **kwargs):
     return subprocess.run(cmd, check=True, capture_output=True, text=True, **kwargs)
 
 
+def close_superseded_prs(repo: str, new_branch: str, canonical_sha: str, gh_env: dict) -> None:
+    """Close any open automated-sync PRs that are not the current sync branch."""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list",
+             "--repo", repo,
+             "--label", "automated-sync",
+             "--state", "open",
+             "--json", "number,headRefName"],
+            capture_output=True, text=True, env=gh_env, check=True,
+        )
+        prs = json.loads(result.stdout or "[]")
+        for pr in prs:
+            if pr["headRefName"] == new_branch:
+                continue
+            subprocess.run(
+                ["gh", "pr", "close", str(pr["number"]),
+                 "--repo", repo,
+                 "--comment",
+                 f"Superseded by {new_branch} (canonical {canonical_sha[:12]})."
+                 " All changes from this PR are included in the newer sync."],
+                env=gh_env, capture_output=True,
+            )
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        pass  # Non-fatal: worst case the old PR stays open
+
+
 def propagate_repo(config: dict, sync_branch: str, canonical_sha: str, dry_run: bool) -> dict:
     repo = config["repo"]
     base_branch = config["branch"]
@@ -141,6 +169,9 @@ def propagate_repo(config: dict, sync_branch: str, canonical_sha: str, dry_run: 
                 result["status"] = "dry_run"
                 return result
 
+            gh_env = {**os.environ, "GH_TOKEN": token}
+            close_superseded_prs(repo, sync_branch, canonical_sha, gh_env)
+
             run(["git", "checkout", "-b", sync_branch], cwd=tmpdir)
             run(["git", "config", "user.email", "sync-bot@openpaws.ai"], cwd=tmpdir)
             run(["git", "config", "user.name", "Open Paws Sync Bot"], cwd=tmpdir)
@@ -152,7 +183,6 @@ def propagate_repo(config: dict, sync_branch: str, canonical_sha: str, dry_run: 
             run(["git", "commit", "-m", commit_msg], cwd=tmpdir)
             run(["git", "push", "origin", sync_branch], cwd=tmpdir)
 
-            gh_env = {**os.environ, "GH_TOKEN": token}
             run(
                 ["gh", "label", "create", "automated-sync",
                  "--repo", repo,


### PR DESCRIPTION
## Problem

When `rules.yaml` receives two commits in quick succession, `propagate.py` opens two sync PRs in each downstream repo. Merging them out of order causes git conflicts — this is exactly what happened with `vale-no-animal-violence#21`, which had to be manually closed as superseded.

## Changes

### `tools/propagate.py` — supersession logic

Before pushing a new sync branch, `close_superseded_prs()` now:
1. Lists open PRs in the downstream repo with the `automated-sync` label
2. Closes any that target a different branch (i.e. older syncs), with a comment explaining they're superseded
3. Failure is non-fatal — if the close fails, the old PR stays open (acceptable)

The `gh_env` dict is now constructed before the git push step so it's available for supersession cleanup.

### `rules.yaml` — 3 new tech terms

Adds `canary-deployment`, `duck-typing`, and `monkey-patching` as `info` severity (awareness-only) entries. These were present in `project-compassionate-code`'s parallel dictionary with `renameable: false` semantics but were missing from the canonical source. Empty `alternatives: []` + `severity: info` maps to `is_documentation_only=True` in downstream consumers — they get flagged for awareness but not auto-replaced.

## Testing

- `close_superseded_prs()` is non-fatal: a `CalledProcessError` or JSON parse failure is caught and logged as a pass
- The function correctly skips the current sync branch when closing older ones
- The 3 new entries follow the existing `info`-severity pattern used for `canary-in-a-coal-mine`, `dogfooding`, `whack-a-mole`, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new content-filtering rules: canary-deployment, duck-typing, and monkey-patching (covers common spelling/compound variants).
  * Sync workflow now automatically identifies and closes superseded synchronization pull requests, with notifications when closures occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->