### PR TITLE
fix(generators): remove DOI references from gen_vale.py and gen_danger.js

### DIFF
--- a/tools/generators/gen_danger.js
+++ b/tools/generators/gen_danger.js
@@ -72,7 +72,7 @@ export default async function noAnimalViolence(options: NoAnimalViolenceOptions 
         report(
           \`**\${file}**: Found "\${pattern.phrase}". \${pattern.reason} \` +
           \`Consider: \${pattern.alternatives.map(a => \`"\${a}"\`).join(" or ")}. \` +
-          \`[Why?](https://doi.org/10.1007/s43681-023-00380-w)\`
+          \`See https://github.com/Open-Paws/no-animal-violence for details.\`
         );
         pattern.regex.lastIndex = 0;
       }

--- a/tools/generators/gen_vale.py
+++ b/tools/generators/gen_vale.py
@@ -23,7 +23,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 BUILD_DIR = REPO_ROOT / "build" / "vale-no-animal-violence" / "NoAnimalViolence"
 
 AUTOGEN_HEADER = "# AUTO-GENERATED from Open-Paws/no-animal-violence. Do not edit directly.\n"
-REFERENCE_URL = "https://doi.org/10.1007/s43681-023-00380-w"
 
 
 def _build_term_index(rules: list[Rule]) -> list[tuple[str, str, str, str]]:
@@ -56,7 +55,6 @@ def _write_vale_file(rules: list[Rule], output_path: Path, level: str = "warning
         AUTOGEN_HEADER,
         "extends: substitution\n",
         f'message: "{message}"\n',
-        f"link: {REFERENCE_URL}\n",
         f"level: {level}\n",
         "ignorecase: true\n",
         "swap:\n",


### PR DESCRIPTION
## Summary

Two generators were injecting a third-party DOI link into their output:

- **gen_vale.py**: Had `REFERENCE_URL = "https://doi.org/10.1007/s43681-023-00380-w"` and emitted `link: {REFERENCE_URL}` into every generated Vale file. Removed constant and the `link:` line — next propagation run will no longer add it to `AnimalIdioms.yml` / `IndustryEuphemisms.yml`.
- **gen_danger.js**: STATIC_FOOTER included `[Why?](https://doi.org/10.1007/s43681-023-00380-w)` appended to every Danger message. Replaced with a link to the canonical Open Paws repo instead.

## Test plan
- [ ] `python3 tools/generators/gen_vale.py` — generated files contain no `link:` field
- [ ] `node tools/generators/gen_danger.js` — generated index.ts messages link to github.com/Open-Paws, not doi.org

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reference link in danger reports to point to the Open-Paws project documentation.
  * Simplified generated Vale configuration files by removing embedded external URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->