### PR TITLE
fix(gen_action): inject bundled .wokeignore allowlist

### DIFF
--- a/.wokeignore
+++ b/.wokeignore
@@ -10,3 +10,7 @@ tools/test_check_consistency.py
 tools/generators/tests/
 .claude/rules/advocacy-domain.md
 INTEGRATION.md
+# Self-referential: scout personas illustrate prohibited patterns in YAML comments
+scout.personas.yaml
+# Self-referential: AGENTS.md describes the alex industry-euphemisms package and references flagged terms
+AGENTS.md

--- a/tools/generators/gen_action.py
+++ b/tools/generators/gen_action.py
@@ -56,7 +56,8 @@ STATIC_FOOTER = """\
       shell: bash
       run: |
         if ! grep -qF "# no-animal-violence-action: canonical paths" .wokeignore 2>/dev/null; then
-          printf '\\n# no-animal-violence-action: canonical paths\\n.claude/rules/\\nCLAUDE.md\\nAGENTS.md\\n' >> .wokeignore
+          printf '\\n# no-animal-violence-action: canonical paths\\n' >> .wokeignore
+          printf '.claude/rules/\\nCLAUDE.md\\nAGENTS.md\\n' >> .wokeignore
         fi
 
     - name: Run animal violence language scan

--- a/tools/generators/gen_action.py
+++ b/tools/generators/gen_action.py
@@ -52,6 +52,13 @@ runs:
 STATIC_FOOTER = """\
         RULES
 
+    - name: Inject canonical Open Paws paths into .wokeignore
+      shell: bash
+      run: |
+        if ! grep -qF "# no-animal-violence-action: canonical paths" .wokeignore 2>/dev/null; then
+          printf '\\n# no-animal-violence-action: canonical paths\\n.claude/rules/\\nCLAUDE.md\\nAGENTS.md\\n' >> .wokeignore
+        fi
+
     - name: Run animal violence language scan
       shell: bash
       run: |

--- a/tools/generators/tests/test_generators.py
+++ b/tools/generators/tests/test_generators.py
@@ -273,3 +273,66 @@ def test_danger_word_boundary(tmp_path):
     # word_boundary:false — no \b prefix
     assert r'"curiosity\\s+killed\\s+the\\s+cat"' in output
     assert r'"\\bcuriosity' not in output
+
+
+def test_gen_action_allowlist_injection(tmp_path):
+    """gen_action injects a .wokeignore block that allowlists canonical AI config paths.
+
+    The STATIC_FOOTER must contain a guarded append block that writes
+    .claude/rules/, CLAUDE.md, and AGENTS.md to .wokeignore so woke does not
+    flag speciesist-language rule definitions in those files. The injection is
+    idempotent (guarded by grep -qF on the marker line).
+
+    This test is RED until STAGE 7 adds the injection block to STATIC_FOOTER.
+    """
+    from gen_action import generate
+
+    rules = load_rules(FIXTURES / "rules_mini.yaml")
+    output_path = tmp_path / "action.yml"
+    generate(rules, output_path)
+    content = output_path.read_text()
+
+    # Structural guard: injection must not break the YAML schema
+    data = yaml.safe_load(content)
+    assert "runs" in data, "action.yml top-level 'runs' key missing — YAML structure broken"
+    assert "steps" in data["runs"], "action.yml runs.steps missing — YAML structure broken"
+
+    # Idempotency marker must be present
+    marker = "# no-animal-violence-action: canonical paths"
+    assert marker in content, (
+        f"Allowlist injection marker {marker!r} not found in generated action.yml"
+    )
+
+    # Each canonical path must appear AFTER the marker (not before, not absent)
+    marker_idx = content.index(marker)
+    for path in (".claude/rules/", "CLAUDE.md", "AGENTS.md"):
+        path_idx = content.find(path, marker_idx)
+        assert path_idx != -1, (
+            f"Canonical path {path!r} not found after allowlist marker in action.yml"
+        )
+
+
+def test_gen_action_woke_command_present(tmp_path):
+    """gen_action output contains the woke --exit-1-on-failure invocation.
+
+    Regression guard: if STATIC_FOOTER loses the woke invocation, this fails.
+    This test is GREEN against the current codebase — it guards against future
+    regression where the footer is refactored and the woke call is accidentally
+    dropped.
+    """
+    from gen_action import generate
+
+    rules = load_rules(FIXTURES / "rules_mini.yaml")
+    output_path = tmp_path / "action.yml"
+    generate(rules, output_path)
+    content = output_path.read_text()
+
+    # Structural guard: output must be valid action YAML
+    data = yaml.safe_load(content)
+    assert "runs" in data, "action.yml top-level 'runs' key missing — YAML structure broken"
+
+    # The woke invocation must be present
+    assert "woke --exit-1-on-failure" in content, (
+        "woke --exit-1-on-failure not found in generated action.yml — "
+        "STATIC_FOOTER may have lost the woke invocation"
+    )


### PR DESCRIPTION
Closes #57

Prepends a guarded `.wokeignore` injection step to `STATIC_FOOTER` in `gen_action.py`. The step uses `>>` (append) with a `grep -qF` idempotency guard on the marker line `# no-animal-violence-action: canonical paths`, so the block writes once even on repeated action runs. Three canonical Open Paws paths are injected: `.claude/rules/`, `CLAUDE.md`, `AGENTS.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated GitHub composite actions now include automatic injection and management of canonical `.wokeignore` configuration, with conditional validation to prevent duplicates.

* **Tests**
  * Added regression tests for the action generator to verify configuration path injection, marker-based validation, and generated output validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->