### PR TITLE
feat(rules): add aquaculture euphemisms for fish/shrimp (fixes #27)

### DIFF
--- a/alex/industry-euphemisms.yml
+++ b/alex/industry-euphemisms.yml
@@ -849,3 +849,48 @@
     own a cat: industry-euphemism
     owns a cat: industry-euphemism
   source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Aquaculture euphemism for killing/slaughtering farmed fish/shrimp. 'Harvest'
+    obscures the mass killing at the end of the grow-out phase.
+  considerate:
+    fish slaughter: a
+    shrimp slaughter: a
+    salmon slaughter: a
+  inconsiderate:
+    fish harvest: industry-euphemism
+    harvesting fish: industry-euphemism
+    shrimp harvest: industry-euphemism
+    harvesting shrimp: industry-euphemism
+    salmon harvest: industry-euphemism
+    tilapia harvest: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Industry term for extreme overcrowding in aquaculture tanks/ponds/net pens,
+    where fish are packed at densities causing stress, disease, and cannibalism.
+  considerate:
+    crowding density: a
+    confinement density: a
+  inconsiderate:
+    stocking density: industry-euphemism
+    stocking densities: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Euphemism for the size/weight at which farmed fish/shrimp are killed ('harvested').
+  considerate:
+    slaughter size: a
+    killing weight: a
+  inconsiderate:
+    harvest size: industry-euphemism
+    market size: industry-euphemism
+    slaughter weight: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w
+- type: basic
+  note: Final fattening phase before slaughter in aquaculture.
+  considerate:
+    fattening pond: a
+    fattening tank: a
+  inconsiderate:
+    grow-out pond: industry-euphemism
+    grow-out tank: industry-euphemism
+    grow-out phase: industry-euphemism
+  source: https://doi.org/10.1007/s43681-023-00380-w

--- a/rules.yaml
+++ b/rules.yaml
@@ -2748,3 +2748,65 @@ rules:
     regex: "own(s|ing|ed)?\\s+a\\s+(pet|dog|cat|rabbit|bird)"
     context_suppressions: []
 
+  - name: aquaculture-harvest
+    terms:
+      - fish harvest
+      - harvesting fish
+      - shrimp harvest
+      - harvesting shrimp
+      - salmon harvest
+      - tilapia harvest
+    alternatives:
+      - fish slaughter
+      - shrimp slaughter
+      - salmon slaughter
+    severity: warning
+    category: industry-euphemism
+    reason: "Aquaculture euphemism for killing/slaughtering farmed fish/shrimp. 'Harvest' obscures the mass killing at the end of the grow-out phase."
+    word_boundary: false
+    regex: "(fish|shrimp|salmon|tilapia)\\s+harvest(ing)?"
+    context_suppressions: []
+
+  - name: stocking-density
+    terms:
+      - stocking density
+      - stocking densities
+    alternatives:
+      - crowding density
+      - confinement density
+    severity: warning
+    category: industry-euphemism
+    reason: "Industry term for extreme overcrowding in aquaculture tanks/ponds/net pens, where fish are packed at densities causing stress, disease, and cannibalism."
+    word_boundary: false
+    regex: "stocking\\s+density(ies)?"
+    context_suppressions: []
+
+  - name: harvest-size
+    terms:
+      - harvest size
+      - market size
+      - slaughter weight
+    alternatives:
+      - slaughter size
+      - killing weight
+    severity: info
+    category: industry-euphemism
+    reason: "Euphemism for the size/weight at which farmed fish/shrimp are killed ('harvested')."
+    word_boundary: false
+    regex: "(harvest|market)\\s+size|slaughter\\s+weight"
+    context_suppressions: []
+
+  - name: grow-out-phase
+    terms:
+      - grow-out pond
+      - grow-out tank
+      - grow-out phase
+    alternatives:
+      - fattening pond
+      - fattening tank
+    severity: info
+    category: industry-euphemism
+    reason: "Final fattening phase before slaughter in aquaculture."
+    word_boundary: false
+    regex: "grow-out\\s+(pond|tank|phase)"
+    context_suppressions: []

--- a/vale/Speciesism/AnimalIdioms.yml
+++ b/vale/Speciesism/AnimalIdioms.yml
@@ -1,7 +1,6 @@
 # AUTO-GENERATED from Open-Paws/no-animal-violence. Do not edit directly.
 extends: substitution
 message: "Consider using '%s' instead of '%s'. This phrase normalizes violence toward animals (see rule comment for why)."
-link: https://doi.org/10.1007/s43681-023-00380-w
 level: warning
 ignorecase: true
 swap:

--- a/vale/Speciesism/IndustryEuphemisms.yml
+++ b/vale/Speciesism/IndustryEuphemisms.yml
@@ -1,7 +1,6 @@
 # AUTO-GENERATED from Open-Paws/no-animal-violence. Do not edit directly.
 extends: substitution
 message: "Consider using '%s' instead of '%s'. This phrase normalizes violence toward animals (see rule comment for why)."
-link: https://doi.org/10.1007/s43681-023-00380-w
 level: warning
 ignorecase: true
 swap:
@@ -555,3 +554,31 @@ swap:
   'own a cat': 'live with a companion animal'
   # own-a-pet: Property framing applied to companion animals. 'Live with a dog' or 'share a home with a cat' captures the relationship without the ownership frame.
   'owns a cat': 'live with a companion animal'
+  # aquaculture-harvest: Aquaculture euphemism for killing/slaughtering farmed fish/shrimp. 'Harvest' obscures the mass killing at the end of the grow-out phase.
+  'fish harvest': 'fish slaughter'
+  # aquaculture-harvest: Aquaculture euphemism for killing/slaughtering farmed fish/shrimp. 'Harvest' obscures the mass killing at the end of the grow-out phase.
+  'harvesting fish': 'fish slaughter'
+  # aquaculture-harvest: Aquaculture euphemism for killing/slaughtering farmed fish/shrimp. 'Harvest' obscures the mass killing at the end of the grow-out phase.
+  'shrimp harvest': 'fish slaughter'
+  # aquaculture-harvest: Aquaculture euphemism for killing/slaughtering farmed fish/shrimp. 'Harvest' obscures the mass killing at the end of the grow-out phase.
+  'harvesting shrimp': 'fish slaughter'
+  # aquaculture-harvest: Aquaculture euphemism for killing/slaughtering farmed fish/shrimp. 'Harvest' obscures the mass killing at the end of the grow-out phase.
+  'salmon harvest': 'fish slaughter'
+  # aquaculture-harvest: Aquaculture euphemism for killing/slaughtering farmed fish/shrimp. 'Harvest' obscures the mass killing at the end of the grow-out phase.
+  'tilapia harvest': 'fish slaughter'
+  # stocking-density: Industry term for extreme overcrowding in aquaculture tanks/ponds/net pens, where fish are packed at densities causing stress, disease, and cannibalism.
+  'stocking density': 'crowding density'
+  # stocking-density: Industry term for extreme overcrowding in aquaculture tanks/ponds/net pens, where fish are packed at densities causing stress, disease, and cannibalism.
+  'stocking densities': 'crowding density'
+  # harvest-size: Euphemism for the size/weight at which farmed fish/shrimp are killed ('harvested').
+  'harvest size': 'slaughter size'
+  # harvest-size: Euphemism for the size/weight at which farmed fish/shrimp are killed ('harvested').
+  'market size': 'slaughter size'
+  # harvest-size: Euphemism for the size/weight at which farmed fish/shrimp are killed ('harvested').
+  'slaughter weight': 'slaughter size'
+  # grow-out-phase: Final fattening phase before slaughter in aquaculture.
+  'grow-out pond': 'fattening pond'
+  # grow-out-phase: Final fattening phase before slaughter in aquaculture.
+  'grow-out tank': 'fattening pond'
+  # grow-out-phase: Final fattening phase before slaughter in aquaculture.
+  'grow-out phase': 'fattening pond'

--- a/woke/.woke.yaml
+++ b/woke/.woke.yaml
@@ -2608,3 +2608,64 @@ rules:
     - industry-euphemism
   reason: Property framing applied to companion animals. 'Live with a dog' or 'share
     a home with a cat' captures the relationship without the ownership frame.
+- name: aquaculture-harvest
+  terms:
+  - fish harvest
+  - harvesting fish
+  - shrimp harvest
+  - harvesting shrimp
+  - salmon harvest
+  - tilapia harvest
+  alternatives:
+  - fish slaughter
+  - shrimp slaughter
+  - salmon slaughter
+  severity: warning
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+  reason: Aquaculture euphemism for killing/slaughtering farmed fish/shrimp. 'Harvest'
+    obscures the mass killing at the end of the grow-out phase.
+- name: stocking-density
+  terms:
+  - stocking density
+  - stocking densities
+  alternatives:
+  - crowding density
+  - confinement density
+  severity: warning
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+  reason: Industry term for extreme overcrowding in aquaculture tanks/ponds/net pens,
+    where fish are packed at densities causing stress, disease, and cannibalism.
+- name: harvest-size
+  terms:
+  - harvest size
+  - market size
+  - slaughter weight
+  alternatives:
+  - slaughter size
+  - killing weight
+  severity: info
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+  reason: Euphemism for the size/weight at which farmed fish/shrimp are killed ('harvested').
+- name: grow-out-phase
+  terms:
+  - grow-out pond
+  - grow-out tank
+  - grow-out phase
+  alternatives:
+  - fattening pond
+  - fattening tank
+  severity: info
+  options:
+    word_boundary: false
+    categories:
+    - industry-euphemism
+  reason: Final fattening phase before slaughter in aquaculture.


### PR DESCRIPTION
Closes #27

## Summary

Adds aquaculture industry euphemism patterns to the no-animal-violence rule set so fish/shrimp/crustacean farming language gets caught alongside terrestrial speciesism patterns.

## Source

Branch was 1 ahead / 0 behind main as of 2026-04-26 — surfaced by the complexity-cut review as ready-to-PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four new language detection rules for aquaculture industry euphemisms. The rules flag terms like "harvest," "stocking density," "harvest size," and "grow-out" phrasing, suggesting direct alternatives to enhance clarity and transparency in content related to fish farming practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->