### PR TITLE
fix(ci): inline woke ignore_files for canonical Open Paws paths

### DIFF
--- a/tools/generators/gen_action.py
+++ b/tools/generators/gen_action.py
@@ -52,14 +52,6 @@ runs:
 STATIC_FOOTER = """\
         RULES
 
-    - name: Inject canonical Open Paws paths into .wokeignore
-      shell: bash
-      run: |
-        if ! grep -qF "# no-animal-violence-action: canonical paths" .wokeignore 2>/dev/null; then
-          printf '\\n# no-animal-violence-action: canonical paths\\n' >> .wokeignore
-          printf '.claude/rules/\\nCLAUDE.md\\nAGENTS.md\\n' >> .wokeignore
-        fi
-
     - name: Run animal violence language scan
       shell: bash
       run: |
@@ -68,9 +60,30 @@ STATIC_FOOTER = """\
           ${{ inputs.paths }}
 """
 
+# Canonical Open Paws paths emitted as woke `ignore_files` patterns (gitignore
+# syntax). These files exist by design across every Open Paws repo and contain
+# domain terms (personas, rule descriptions) that the scanner would otherwise
+# flag on every PR. Inlining them here is plan v2 for #65 — the previous
+# .wokeignore mutation step never propagated to the deployed action.yml.
+CANONICAL_IGNORE_FILES = [
+    "**/*personas.yaml",
+    "scout.personas.yaml",
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".claude/rules/",
+]
+
 
 def _build_woke_yaml(rules: list[Rule], indent: int = 8) -> str:
-    """Render rules in woke YAML format, indented for heredoc embedding."""
+    """Render rules in woke YAML format, indented for heredoc embedding.
+
+    Emits two top-level keys:
+      - `ignore_files`: list of gitignore-style patterns telling woke to skip
+        the canonical Open Paws files (personas fixtures, AGENTS.md, CLAUDE.md,
+        .claude/rules/) at scan time. Per woke pkg/config/config.go this maps
+        to `IgnoreFiles []string` — must be a list, never a single string.
+      - `rules`: the rule entries woke matches against.
+    """
     pad = " " * indent
     rules_list = []
     for rule in rules:
@@ -87,7 +100,10 @@ def _build_woke_yaml(rules: list[Rule], indent: int = 8) -> str:
         entry["reason"] = rule.reason
         rules_list.append(entry)
     dumped = yaml.safe_dump(
-        {"rules": rules_list},
+        {
+            "ignore_files": list(CANONICAL_IGNORE_FILES),
+            "rules": rules_list,
+        },
         default_flow_style=False,
         sort_keys=False,
         allow_unicode=True,

--- a/tools/generators/tests/test_generators.py
+++ b/tools/generators/tests/test_generators.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -275,15 +276,140 @@ def test_danger_word_boundary(tmp_path):
     assert r'"\\bcuriosity' not in output
 
 
-def test_gen_action_allowlist_injection(tmp_path):
-    """gen_action injects a .wokeignore block that allowlists canonical AI config paths.
+CANONICAL_IGNORE_PATHS = [
+    "scout.personas.yaml",
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".claude/rules/",
+]
 
-    The STATIC_FOOTER must contain a guarded append block that writes
-    .claude/rules/, CLAUDE.md, and AGENTS.md to .wokeignore so woke does not
-    flag speciesist-language rule definitions in those files. The injection is
-    idempotent (guarded by grep -qF on the marker line).
 
-    This test is RED until STAGE 7 adds the injection block to STATIC_FOOTER.
+def _extract_woke_yaml_body(action_yml_text: str) -> dict:
+    """Parse the embedded /tmp/.woke.yaml HEREDOC body out of a generated action.yml.
+
+    The action.yml ships a composite step that writes /tmp/.woke.yaml via a
+    bash heredoc:
+
+        cat > /tmp/.woke.yaml << 'RULES'
+        <yaml body, 8-space indented>
+        RULES
+
+    This helper extracts the body between the heredoc opener and the RULES
+    sentinel, dedents the 8-space indent woke needs, and parses the result as
+    YAML so tests can assert against the actual schema woke will see at runtime.
+    Returns the parsed dict.
+    """
+    opener = "cat > /tmp/.woke.yaml << 'RULES'"
+    assert opener in action_yml_text, (
+        f"action.yml has no {opener!r} heredoc opener — generator structure changed"
+    )
+    after_opener = action_yml_text.split(opener, 1)[1]
+    # The closing sentinel "RULES" sits on its own line, indented to match the
+    # cat invocation. Match it as the first line that is exactly whitespace + RULES.
+    body_lines: list[str] = []
+    for line in after_opener.splitlines()[1:]:
+        if line.strip() == "RULES":
+            break
+        body_lines.append(line)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("RULES heredoc terminator not found after opener")
+    # Dedent: the body is indented 8 spaces inside the composite step's run: |.
+    # Use a permissive dedent so tests survive whitespace re-jiggering as long
+    # as every body line shares a common leading indent.
+    indent = min(
+        (len(line) - len(line.lstrip(" ")) for line in body_lines if line.strip()),
+        default=0,
+    )
+    dedented = "\n".join(line[indent:] for line in body_lines)
+    parsed = yaml.safe_load(dedented)
+    assert isinstance(parsed, dict), (
+        f"woke YAML body did not parse as a mapping (got {type(parsed).__name__})"
+    )
+    return parsed
+
+
+def test_build_woke_yaml_emits_ignore_files_as_list_of_strings():
+    """_build_woke_yaml emits an `ignore_files` key whose value is a list of strings.
+
+    Per woke source (pkg/config/config.go), `IgnoreFiles []string` is a list of
+    inline gitignore-style PATTERNS — not a pointer to a .wokeignore file. The
+    schema is `[]string`. A single-string value would silently fail at runtime
+    (woke would treat it as one literal pattern), so this test asserts both
+    presence and the list-of-strings shape.
+
+    Mutation resistance:
+      - Mutate `ignore_files: [...]` → omit key → fails on key check.
+      - Mutate `ignore_files: [...]` → `ignore_files: ".wokeignore"` (the
+        v1-plan bug) → fails on `isinstance(value, list)`.
+      - Mutate any list element to non-string → fails on per-element type.
+    """
+    from gen_action import _build_woke_yaml
+
+    rules = load_rules(FIXTURES / "rules_mini.yaml")
+    rendered = _build_woke_yaml(rules, indent=0)
+    parsed = yaml.safe_load(rendered)
+
+    assert isinstance(parsed, dict), (
+        f"_build_woke_yaml output did not parse as a mapping "
+        f"(got {type(parsed).__name__})"
+    )
+    assert "ignore_files" in parsed, (
+        "_build_woke_yaml output missing top-level 'ignore_files' key — "
+        "woke will not skip canonical Open Paws paths"
+    )
+    ignore_files = parsed["ignore_files"]
+    assert isinstance(ignore_files, list), (
+        f"'ignore_files' must be a list (woke schema is []string), got "
+        f"{type(ignore_files).__name__}: {ignore_files!r}"
+    )
+    assert len(ignore_files) >= 1, "'ignore_files' must not be empty"
+    for entry in ignore_files:
+        assert isinstance(entry, str), (
+            f"every 'ignore_files' entry must be a string, got "
+            f"{type(entry).__name__}: {entry!r}"
+        )
+
+    # Rules key must still be present alongside ignore_files (not replaced).
+    assert "rules" in parsed, (
+        "_build_woke_yaml dropped the 'rules' key when adding ignore_files — "
+        "woke would have nothing to scan for"
+    )
+    assert isinstance(parsed["rules"], list) and len(parsed["rules"]) >= 1, (
+        "'rules' key must remain a non-empty list"
+    )
+
+
+def test_build_woke_yaml_ignore_files_contains_canonical_paths():
+    """_build_woke_yaml's `ignore_files` list contains every canonical path.
+
+    Mutation resistance: dropping any one of the canonical paths flips this
+    assertion. Substring matching is rejected — exact equality on the entry
+    string catches drift like `scout.personas.yml` (wrong extension) or
+    `.claude/rules` (missing trailing slash, which changes gitignore semantics).
+    """
+    from gen_action import _build_woke_yaml
+
+    rules = load_rules(FIXTURES / "rules_mini.yaml")
+    parsed = yaml.safe_load(_build_woke_yaml(rules, indent=0))
+    ignore_files = parsed["ignore_files"]
+
+    for canonical in CANONICAL_IGNORE_PATHS:
+        assert canonical in ignore_files, (
+            f"canonical Open Paws path {canonical!r} missing from "
+            f"_build_woke_yaml ignore_files list (got {ignore_files!r})"
+        )
+
+
+def test_gen_action_woke_config_has_ignore_files(tmp_path):
+    """Generated action.yml's embedded woke YAML carries ignore_files inline.
+
+    End-to-end: generate the full action.yml, extract the /tmp/.woke.yaml
+    HEREDOC body, parse it, and assert it has `ignore_files` shaped as a list
+    of strings containing the canonical paths. This is the contract test —
+    `_build_woke_yaml` is internal, but the embedded heredoc body is the
+    runtime contract with woke 0.19.0.
+
+    Mutation resistance via YAML parse, not substring match.
     """
     from gen_action import generate
 
@@ -292,24 +418,160 @@ def test_gen_action_allowlist_injection(tmp_path):
     generate(rules, output_path)
     content = output_path.read_text()
 
-    # Structural guard: injection must not break the YAML schema
-    data = yaml.safe_load(content)
-    assert "runs" in data, "action.yml top-level 'runs' key missing — YAML structure broken"
-    assert "steps" in data["runs"], "action.yml runs.steps missing — YAML structure broken"
-
-    # Idempotency marker must be present
-    marker = "# no-animal-violence-action: canonical paths"
-    assert marker in content, (
-        f"Allowlist injection marker {marker!r} not found in generated action.yml"
+    # Outer action.yml schema must still parse.
+    outer = yaml.safe_load(content)
+    assert "runs" in outer and "steps" in outer["runs"], (
+        "action.yml outer YAML structure broken"
     )
 
-    # Each canonical path must appear AFTER the marker (not before, not absent)
-    marker_idx = content.index(marker)
-    for path in (".claude/rules/", "CLAUDE.md", "AGENTS.md"):
-        path_idx = content.find(path, marker_idx)
-        assert path_idx != -1, (
-            f"Canonical path {path!r} not found after allowlist marker in action.yml"
+    woke_config = _extract_woke_yaml_body(content)
+    assert "ignore_files" in woke_config, (
+        "embedded /tmp/.woke.yaml heredoc body missing 'ignore_files' — "
+        "woke will not skip fixture files at runtime"
+    )
+    ignore_files = woke_config["ignore_files"]
+    assert isinstance(ignore_files, list), (
+        f"embedded woke ignore_files must be a list, got {type(ignore_files).__name__}"
+    )
+    for canonical in CANONICAL_IGNORE_PATHS:
+        assert canonical in ignore_files, (
+            f"canonical path {canonical!r} missing from embedded woke "
+            f"ignore_files list (got {ignore_files!r})"
         )
+
+
+def test_gen_action_woke_config_includes_scout_personas_yaml(tmp_path):
+    """Regression test for #65: scout.personas.yaml MUST be in ignore_files.
+
+    The bug in #65 is specifically that `scout.personas.yaml` (a fixture file
+    full of personas with phrases like 'guinea pig' on purpose, to exercise
+    the rules) was being scanned by woke and flagged on every PR. The fix is
+    that scout.personas.yaml ends up in the woke config's ignore_files list.
+
+    This test fails specifically if a future refactor drops scout.personas.yaml
+    from the canonical paths list — even if the other three paths remain.
+    """
+    from gen_action import generate
+
+    rules = load_rules(FIXTURES / "rules_mini.yaml")
+    output_path = tmp_path / "action.yml"
+    generate(rules, output_path)
+
+    woke_config = _extract_woke_yaml_body(output_path.read_text())
+    ignore_files = woke_config.get("ignore_files", [])
+    assert "scout.personas.yaml" in ignore_files, (
+        "scout.personas.yaml is the #65 regression case — it MUST appear in "
+        f"the woke config ignore_files list. Got: {ignore_files!r}"
+    )
+
+
+def test_gen_action_woke_ignore_patterns_match_fixture_files(tmp_path):
+    """Integration test: emitted ignore_files patterns actually skip fixture files.
+
+    Simulates woke's runtime matching by feeding the generator's ignore_files
+    list into a gitignore-pattern matcher (the same algorithm woke uses via
+    go-git/go-git's gitignore parser, but in Python via `pathspec`). Builds a
+    fixture repo with scout.personas.yaml plus a non-fixture file, and asserts
+    that the patterns skip the fixture and do NOT skip the regular file.
+
+    This catches the failure mode where ignore_files contains the right path
+    strings but in a syntax that doesn't actually match (e.g. missing leading
+    slash, wrong glob form, trailing-slash semantics drift).
+
+    Mutation resistance: drop scout.personas.yaml from canonical paths -> the
+    fixture file is no longer matched -> test fails. Replace bare filenames
+    with absolute-only patterns -> bare files at deeper paths stop matching
+    -> test fails on the nested case.
+    """
+    pathspec = pytest.importorskip("pathspec")  # noqa: F841
+
+    from gen_action import _build_woke_yaml
+
+    rules = load_rules(FIXTURES / "rules_mini.yaml")
+    parsed = yaml.safe_load(_build_woke_yaml(rules, indent=0))
+    ignore_patterns = parsed.get("ignore_files", [])
+    assert isinstance(ignore_patterns, list) and ignore_patterns, (
+        "ignore_files must be a non-empty list to test runtime matching"
+    )
+
+    import pathspec as _pathspec
+    spec = _pathspec.PathSpec.from_lines(
+        _pathspec.patterns.GitWildMatchPattern,
+        ignore_patterns,
+    )
+
+    # Files that MUST match (be skipped by woke at runtime).
+    must_match = [
+        "scout.personas.yaml",          # at root — primary #65 case
+        "AGENTS.md",
+        "CLAUDE.md",
+        ".claude/rules/some-rule.md",   # under canonical rules dir
+        "subdir/scout.personas.yaml",   # bare-filename gitignore matches at any depth
+    ]
+    for path in must_match:
+        assert spec.match_file(path), (
+            f"emitted ignore_files patterns {ignore_patterns!r} do not match "
+            f"{path!r} — woke would scan it at runtime and #65 reproduces"
+        )
+
+    # Files that MUST NOT match (regular code/docs that should still be scanned).
+    must_not_match = [
+        "src/main.py",
+        "README.md",
+        "docs/index.md",
+        "tools/generators/gen_action.py",
+    ]
+    for path in must_not_match:
+        assert not spec.match_file(path), (
+            f"emitted ignore_files patterns {ignore_patterns!r} unexpectedly "
+            f"match {path!r} — over-broad ignore would silence real findings"
+        )
+
+
+def test_gen_action_static_footer_drops_wokeignore_injection_step(tmp_path):
+    """Plan v2 drops the never-propagated `.wokeignore` injection step.
+
+    Path A inlines the canonical paths into the woke YAML config's
+    `ignore_files:` key. The shell step that mutated consumer `.wokeignore`
+    files (a) never propagated to the deployed action.yml, and (b) is
+    redundant under Path A. Plan v2 explicitly removes it.
+
+    This test asserts the artifacts of that step are gone from the generated
+    action.yml. It fails on the current codebase (the step is still there)
+    and goes green when STAGE 7 deletes the step from STATIC_FOOTER.
+
+    Mutation resistance: any of the three step artifacts (step name, sentinel
+    comment, append-to-.wokeignore command) coming back trips the test.
+    """
+    from gen_action import generate
+
+    rules = load_rules(FIXTURES / "rules_mini.yaml")
+    output_path = tmp_path / "action.yml"
+    generate(rules, output_path)
+    content = output_path.read_text()
+
+    # Outer schema still valid (the deletion mustn't break the action).
+    data = yaml.safe_load(content)
+    assert "runs" in data and "steps" in data["runs"], (
+        "action.yml outer YAML structure broken after STATIC_FOOTER edit"
+    )
+
+    forbidden_artifacts = [
+        # The composite-step name.
+        "Inject canonical Open Paws paths into .wokeignore",
+        # The idempotency sentinel comment line.
+        "# no-animal-violence-action: canonical paths",
+        # The mutation command — appending to consumer .wokeignore.
+        ">> .wokeignore",
+    ]
+    for artifact in forbidden_artifacts:
+        assert artifact not in content, (
+            f"STATIC_FOOTER still contains {artifact!r} — plan v2 removes the "
+            "wokeignore-injection step entirely (canonical paths now live in "
+            "the woke YAML ignore_files key, not in consumer .wokeignore)"
+        )
+
+
 
 
 def test_gen_action_woke_command_present(tmp_path):


### PR DESCRIPTION
## Summary

Plan v2 for #65. The previous approach (composite step that appended canonical paths to consumer `.wokeignore` at runtime) never propagated to the deployed `action.yml` because consumers pull a tagged release, not source. Result: `scout.personas.yaml` and other fixture files keep flagging on every PR fleet-wide.

This PR inlines the canonical paths into the embedded `/tmp/.woke.yaml` config as an `ignore_files: []` list (woke schema is `IgnoreFiles []string` — gitignore-syntax patterns). woke skips them at scan time, no consumer-side `.wokeignore` mutation needed. The redundant injection step is dropped from `STATIC_FOOTER` entirely.

Patterns emitted:
- `**/*personas.yaml`
- `scout.personas.yaml`
- `AGENTS.md`
- `CLAUDE.md`
- `.claude/rules/`

Bare filenames match at any depth via gitignore semantics, so `subdir/scout.personas.yaml` still gets skipped.

## Test plan

- [x] 6 RED tests in `tools/generators/tests/test_generators.py` confirmed failing pre-change (commit `a8c08d4`)
- [x] All 6 GREEN after this commit (`a80bfe5`)
- [x] Full suite: 22 passed, 3 pre-existing env failures (`js-yaml` Node module not installed locally — unrelated to #65, fail on `main` too)
- [x] End-to-end smoke: `python tools/generators/gen_action.py` against canonical `rules.yaml` produces valid action.yml with embedded woke config carrying `ignore_files` + 162 rules
- [x] `pathspec` integration test: emitted patterns match all canonical fixture paths and don't over-match real source files

## Fleet impact

Once this lands and a tagged release goes out, every downstream NAV-tooling repo's `.github/workflows/nav-check.yml` (regenerated from `gen_action.py`) needs re-propagation. Out of scope for this PR — autosync/regeneration handles that as a separate stage.

Closes #65