### PR TITLE
fix(rules): tighten stocking-density and harvest-size regexes

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -2778,7 +2778,7 @@ rules:
     category: industry-euphemism
     reason: "Industry term for extreme overcrowding in aquaculture tanks/ponds/net pens, where fish are packed at densities causing stress, disease, and cannibalism."
     word_boundary: false
-    regex: "stocking\\s+density(ies)?"
+    regex: "\\bstocking\\s+densit(?:y|ies)\\b"
     context_suppressions: []
 
   - name: harvest-size
@@ -2793,7 +2793,7 @@ rules:
     category: industry-euphemism
     reason: "Euphemism for the size/weight at which farmed fish/shrimp are killed ('harvested')."
     word_boundary: false
-    regex: "(harvest|market)\\s+size|slaughter\\s+weight"
+    regex: "\\b(?:fish|shrimp|salmon|tilapia)\\s+(?:harvest|market)\\s+size\\b|\\bslaughter\\s+weight\\b|\\bharvest\\s+size\\b"
     context_suppressions: []
 
   - name: grow-out-phase


### PR DESCRIPTION
## Summary

Tightens two regexes in the aquaculture rules added by #63, both surfaced by CodeRabbit on the active sync PRs (e.g. [Open-Paws/eslint-plugin-no-animal-violence#36](https://github.com/Open-Paws/eslint-plugin-no-animal-violence/pull/36) review). Refs #70.

### `stocking-density`

Previous regex `stocking\s+density(ies)?` matches `stocking density` or the nonsense `stocking densityies` — but **never `stocking densities`**, which is one of the documented terms for the rule. The `y` is required by the literal, then `(ies)?` is appended after it.

```
- regex: "stocking\\s+density(ies)?"
+ regex: "\\bstocking\\s+densit(?:y|ies)\\b"
```

The fix uses an alternation `densit(?:y|ies)` to match both forms, plus `\b` word boundaries to prevent partial matches like `blockstocking density`.

### `harvest-size`

Previous regex `(harvest|market)\s+size|slaughter\s+weight` is too broad — `market\s+size` fires on **any** "market size" appearance (e.g. "global market size forecast", "addressable market size", "smartphone market size in 2024"), generating false positives in business writing entirely unrelated to aquaculture.

```
- regex: "(harvest|market)\\s+size|slaughter\\s+weight"
+ regex: "\\b(?:fish|shrimp|salmon|tilapia)\\s+(?:harvest|market)\\s+size\\b|\\bslaughter\\s+weight\\b|\\bharvest\\s+size\\b"
```

The fix scopes `market size` to aquaculture context (must be preceded by `fish`/`shrimp`/`salmon`/`tilapia`) while keeping bare `harvest size` and `slaughter weight` unconditional, since those are aquaculture-specific terminology that doesn't need a species qualifier.

## Verification

Sanity-tested both regexes locally:

```python
# stocking-density
'stocking density'      -> True   ✓
'stocking densities'    -> True   ✓ (was False before)
'stocking densityies'   -> False  ✓
'blockstocking density' -> False  ✓

# harvest-size
'tilapia market size target'    -> True   ✓
'fish harvest size'             -> True   ✓
'shrimp market size'            -> True   ✓
'harvest size'                  -> True   ✓
'slaughter weight threshold'    -> True   ✓
'global market size forecast'   -> False  ✓ (was True before)
'addressable market size'       -> False  ✓ (was True before)
'smartphone market size in 2024'-> False  ✓ (was True before)
```

Regenerated all downstream artifacts via `python tools/generate_all.py`; verified the corrected regexes appear correctly in:
- `build/eslint-plugin-no-animal-violence/lib/rules/no-violent-language.js`
- `build/semgrep-rules-no-animal-violence/rules/animal-violence-generic.yaml`
- (and the rest of the downstream targets)

Test results:
- `tools/generators/tests/` — **24 passed, 1 skipped**
- `tools/test_check_consistency.py` — **20 passed**

## Test plan

- [x] Verified `densities` now matches and `densityies` no longer matches
- [x] Verified business-writing "market size" no longer false-positives
- [x] Aquaculture-context "market size" still matches (`fish`/`shrimp`/`salmon`/`tilapia` qualifier)
- [x] All existing generator + consistency tests pass
- [x] All 11 downstream generator outputs regenerate cleanly with the new regexes

## Context

Once this lands, please re-run `propagate.yml` so the corrected regexes — along with the `ignore_files` fix from #66, which still hasn't propagated — reach the 6 downstream sync PRs that are currently OPEN-but-BLOCKED. See #70 for the full ecosystem audit + roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined aquaculture-related matching patterns to improve accuracy by enhancing word boundary detection and reducing false positives in stocking-density and harvest-size matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->